### PR TITLE
Add testnet disclaimer

### DIFF
--- a/docs/build/dev-workflow.md
+++ b/docs/build/dev-workflow.md
@@ -5,6 +5,12 @@ sidebar_label: 'Developer workflow'
 
 # Developer workflow
 
+:::caution Disclaimer
+
+The Polymer testnet is currently in a private testing phase. Please be aware that during this phase, the network may be subject to instability, downtime, and data resets. Read the full disclaimer [here](disclaimer.md).
+
+:::
+
 :::info Who's this section for?
 
 A number of different actors might be interested in interacting with Polymer, and different sections of the documentation apply to each.

--- a/docs/build/disclaimer.md
+++ b/docs/build/disclaimer.md
@@ -1,0 +1,38 @@
+---
+sidebar_position: 5
+sidebar_label: 'Disclaimer'
+---
+
+# Disclaimer for Polymer Testnet
+
+The Polymer testnet is currently in a private testing phase. The purpose of this phase is to conduct thorough testing, identify potential issues, and ensure the stability and reliability of the network before its public release. Please be aware that during this phase, the network may be subject to instability, downtime, and data resets.
+
+## Limited Liability
+
+By accessing and using the Polymer testnet, you acknowledge and agree that:
+
+1. The testnet is provided "as is" and "as available," without any warranties or guarantees of any kind, either express or implied, including but not limited to warranties of merchantability, fitness for a particular purpose, or non-infringement.
+   
+2. The Polymer Labs team and any affiliated parties are not liable for any direct, indirect, incidental, consequential, or exemplary damages arising from your use of the testnet or inability to use the testnet, even if advised of the possibility of such damages.
+   
+3. The Polymer Labs team reserves the right to modify, suspend, or discontinue the testnet at any time without notice or liability.
+
+## Data Persistence and Privacy
+
+Please note that:
+
+1. Data created or stored on the testnet (including accounts, transactions, and smart contracts) may be periodically wiped without notice. We recommend not using the testnet to store any valuable or sensitive information.
+
+2. While we strive to ensure the privacy and security of all testnet participants, we cannot guarantee complete confidentiality due to the experimental nature of this phase. Please refrain from transmitting or storing sensitive personal information on the testnet.
+
+## Participation and Feedback
+
+Your participation in the testnet is voluntary and highly valued. We encourage you to report any issues, bugs, or vulnerabilities you encounter to help us improve the stability and functionality of the network. Please submit your feedback through [the Polymer Developer Forum](https://forum.polymerlabs.org).
+
+## Agreement
+
+By accessing and using the Polymer testnet, you agree to the terms outlined in this disclaimer. If you do not agree with these terms, please refrain from using the testnet.
+
+## Contact Information
+
+For any questions or concerns regarding this disclaimer or the testnet, please contact us at build@polymerlabs.org .

--- a/docs/build/events.md
+++ b/docs/build/events.md
@@ -5,6 +5,12 @@ sidebar_label: 'Debug packet cycle'
 
 # Events overview for vIBC
 
+:::caution Disclaimer
+
+The Polymer testnet is currently in a private testing phase. Please be aware that during this phase, the network may be subject to instability, downtime, and data resets. Read the full disclaimer [here](disclaimer.md).
+
+:::
+
 When debugging the IBC packet lifecycle, the first step to take is to track down the packet during its lifecyle and where any potential issue arises.
 
 As an application developer, you'll be mostly looking at the events on the chains your application(s) live on, not Polymer itself in the middle. 

--- a/docs/build/supp-networks.md
+++ b/docs/build/supp-networks.md
@@ -5,6 +5,12 @@ sidebar_label: 'Network Information'
 
 # Supported networks & dispatcher contracts
 
+:::caution Disclaimer
+
+The Polymer testnet is currently in a private testing phase. Please be aware that during this phase, the network may be subject to instability, downtime, and data resets. Read the full disclaimer [here](disclaimer.md).
+
+:::
+
 Here you'll find an overview of the networks Polymer currently supports and where to find the address of the Dispatcher contract.
 
 ## Supported networks (testnet)

--- a/docs/learn/_category_.json
+++ b/docs/learn/_category_.json
@@ -1,6 +1,6 @@
 {
     "label" : "Learn",
-    "position" : 2,
+    "position" : 1,
     "link" : {
         "type" : "generated-index",
         "description" : "Learn the fundamental concepts behind Polymer"

--- a/docs/quickstart/disclaimer.md
+++ b/docs/quickstart/disclaimer.md
@@ -1,0 +1,38 @@
+---
+sidebar_position: 4
+sidebar_label: 'Disclaimer'
+---
+
+# Disclaimer for Polymer Testnet
+
+The Polymer testnet is currently in a private testing phase. The purpose of this phase is to conduct thorough testing, identify potential issues, and ensure the stability and reliability of the network before its public release. Please be aware that during this phase, the network may be subject to instability, downtime, and data resets.
+
+## Limited Liability
+
+By accessing and using the Polymer testnet, you acknowledge and agree that:
+
+1. The testnet is provided "as is" and "as available," without any warranties or guarantees of any kind, either express or implied, including but not limited to warranties of merchantability, fitness for a particular purpose, or non-infringement.
+   
+2. The Polymer Labs team and any affiliated parties are not liable for any direct, indirect, incidental, consequential, or exemplary damages arising from your use of the testnet or inability to use the testnet, even if advised of the possibility of such damages.
+   
+3. The Polymer Labs team reserves the right to modify, suspend, or discontinue the testnet at any time without notice or liability.
+
+## Data Persistence and Privacy
+
+Please note that:
+
+1. Data created or stored on the testnet (including accounts, transactions, and smart contracts) may be periodically wiped without notice. We recommend not using the testnet to store any valuable or sensitive information.
+
+2. While we strive to ensure the privacy and security of all testnet participants, we cannot guarantee complete confidentiality due to the experimental nature of this phase. Please refrain from transmitting or storing sensitive personal information on the testnet.
+
+## Participation and Feedback
+
+Your participation in the testnet is voluntary and highly valued. We encourage you to report any issues, bugs, or vulnerabilities you encounter to help us improve the stability and functionality of the network. Please submit your feedback through [the Polymer Developer Forum](https://forum.polymerlabs.org).
+
+## Agreement
+
+By accessing and using the Polymer testnet, you agree to the terms outlined in this disclaimer. If you do not agree with these terms, please refrain from using the testnet.
+
+## Contact Information
+
+For any questions or concerns regarding this disclaimer or the testnet, please contact us at build@polymerlabs.org .

--- a/docs/quickstart/index.md
+++ b/docs/quickstart/index.md
@@ -5,6 +5,12 @@ sidebar_label: 'Send a packet <5 mins'
 
 # Quickstart: send a packet in under 5 mins
 
+:::caution Disclaimer
+
+The Polymer testnet is currently in a private testing phase. Please be aware that during this phase, the network may be subject to instability, downtime, and data resets. Read the full disclaimer [here](disclaimer.md).
+
+:::
+
 :::tip Goals
 
 This quickstart tutorial aims to have you send an IBC packet from OP Sepolia to Base Sepolia with a minimal setup. This way you'll get a feel for the IBC packet lifecycle when using Polymer.

--- a/docs/quickstart/tutorial1.md
+++ b/docs/quickstart/tutorial1.md
@@ -5,6 +5,12 @@ sidebar_label: 'Proof-of-Vote NFT - Part 1'
 
 # Cross-chain Proof-of-Vote NFT - Custom IBC channel
 
+:::caution Disclaimer
+
+The Polymer testnet is currently in a private testing phase. Please be aware that during this phase, the network may be subject to instability, downtime, and data resets. Read the full disclaimer [here](disclaimer.md).
+
+:::
+
 :::tip Goals
 
 After going through this tutorial, developers will be able to:


### PR DESCRIPTION
Closes: #28 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added cautionary disclaimers for the private testing phase of the Polymer testnet in various documentation files.
	- Added a new `disclaimer.md` file outlining the Polymer testnet's private testing phase, limited liability, data persistence, privacy, participation, agreement, and contact information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->