### PR TITLE
add git submodules to tutorials for dep management

### DIFF
--- a/docs/quickstart/index.md
+++ b/docs/quickstart/index.md
@@ -45,6 +45,11 @@ Then, install the dependencies:
 ```bash
 npm install
 ```
+and the git submodules.
+
+```bash
+git submodule update --init --recursive
+```
 ### Store your private keys
 
 In the `hardhat.config.js` file in the root directory, you'll see that you need to define 3 private keys (can be the same for OP and Base), in an `.env` file to load them as an environment variable to sign transactions.

--- a/docs/quickstart/tutorial1.md
+++ b/docs/quickstart/tutorial1.md
@@ -69,6 +69,11 @@ Then, install the dependencies:
 ```bash
 npm install
 ```
+and the git submodules.
+
+```bash
+git submodule update --init --recursive
+```
 ### Store private keys
 
 In the `hardhat.config.js` file in the root directory, you'll see that you need to define 3 private keys (can be the same for OP and Base), in an `.env` file to load them as an environment variable to sign transactions.

--- a/docs/quickstart/tutorial2.md
+++ b/docs/quickstart/tutorial2.md
@@ -69,6 +69,11 @@ Then, install the dependencies:
 ```bash
 npm install
 ```
+and the git submodules.
+
+```bash
+git submodule update --init --recursive
+```
 ### Store private keys
 
 In the `hardhat.config.js` file in the root directory, you'll see that you need to define 3 private keys (can be the same for OP and Base), in an `.env` file to load them as an environment variable to sign transactions.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated quickstart guide and tutorials with instructions for installing git submodules and defining private keys in the `hardhat.config.js` file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->