### PR TITLE
fix command typo

### DIFF
--- a/docs/quickstart/start.md
+++ b/docs/quickstart/start.md
@@ -76,7 +76,7 @@ Run the following command to go through a full E2E sweep of the project:
 
 ```bash
 # Usage: just do-it
-just do it
+just do-it
 ```
 
 It does the following under the hood:


### PR DESCRIPTION
`just do it` should be `just do-it`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the command usage instructions for consistency and clarity in the Quick Start guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->