### PR TITLE
Create Fix sub-module command

### DIFF
--- a/Fix sub-module command
+++ b/Fix sub-module command
@@ -1,0 +1,12 @@
+nclude the vIBC core smart contracts to your project by running the following command into your project:
+
+git add submodule https://github.com/open-ibc/vibc-core-smart-contracts.git [optional-destination-path]
+git submodule add https://github.com/open-ibc/vibc-core-smart-contracts.git [optional-destination-path]
+
+You can then import for example the IbcReceiver interface to extend your IBC enabled contract, like so:
+@@ -66,4 +66,4 @@ contract MyIbcContract is IbcReceiver {
+}
+`
+
+Continue on to the [next section](ibc-solidity.md) to see how to implement the interfaces to write IBC enabled smart contracts.
+Continue on to the [next section](ibc-solidity.md) to see how to implement the interfaces to write IBC enabled smart contracts.


### PR DESCRIPTION
nclude the vIBC core smart contracts to your project by running the following command into your project:

git add submodule https://github.com/open-ibc/vibc-core-smart-contracts.git [optional-destination-path] git submodule add https://github.com/open-ibc/vibc-core-smart-contracts.git [optional-destination-path]

You can then import for example the IbcReceiver interface to extend your IBC enabled contract, like so: @@ -66,4 +66,4 @@ contract MyIbcContract is IbcReceiver { }
`

Continue on to the [next section](ibc-solidity.md) to see how to implement the interfaces to write IBC enabled smart contracts. Continue on to the [next section](ibc-solidity.md) to see how to implement the interfaces to write IBC enabled smart contracts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added instructions for including vIBC core smart contracts in projects using Git submodules, including commands for adding smart contracts as submodules and guidance on importing the IbcReceiver interface for extending IBC enabled contracts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->