### PR TITLE
Fix typos and update social link in documentation

### DIFF
--- a/docs/learn/how-it-works/latency-can-vary.md
+++ b/docs/learn/how-it-works/latency-can-vary.md
@@ -21,8 +21,8 @@ This is practical example with Base and Optimism on Ethereum mainnet. Both have 
 
 :::
 
-### Implecations
-- **Rollup Knowledge:** Optimism references Ethereum up to 11 blocks deep, while Base references up to 16 blocks. This mean the Optimism lacks the knowledge of Ethereum beyond the 11th block and for Base this is even larger i.e the first 16 Ethereum blocks.
+### Implications
+- **Rollup Knowledge:** Optimism references Ethereum up to 11 blocks deep, while Base references up to 16 blocks.  This means that Optimism lacks the knowledge of Ethereum beyond the 11th block and for Base this is even larger i.e the first 16 Ethereum blocks.
 
 ![image (37)](https://github.com/user-attachments/assets/20128dcb-59e0-415b-b1f4-99eec6128452)
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -123,8 +123,8 @@ const config = {
                 href: 'https://discord.gg/hvMQp4qcM6',
               },
               {
-                label: 'Twitter',
-                href: 'https://twitter.com/Polymer_Labs',
+                label: 'X',
+                href: 'https://x.com/Polymer_Labs',
               },
             ],
           },


### PR DESCRIPTION
**This PR includes the following changes:**

**1. Updated social link label and URL:**

- Changed label from Twitter to X.
- Updated the URL from https://twitter.com/Polymer_Labs to https://x.com/Polymer_Labs.


**3.  Fixed typos in "Why Latency Can Vary" documentation:**

- Corrected "Implecations" to "Implications."
- Updated "This mean the Optimism lacks..." to "This means that Optimism lacks..."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Corrected typographical and grammatical errors in the latency document for improved clarity.
	- Updated content regarding the implications of Optimism and Base on Ethereum blocks.

- **Chores**
	- Changed the "Twitter" link to "X" in the footer of the Docusaurus configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->