### PR TITLE
fix typo

### DIFF
--- a/docs/build/prove-api/api-endpoints.mdx
+++ b/docs/build/prove-api/api-endpoints.mdx
@@ -42,12 +42,10 @@ Authorization: Bearer <token>
 {
   "jsonrpc": "2.0",
   "id": 1,
-  "result": {
-    "jobID": [int64]
-  }
+  "result": int64
 }
 ```
-The response contains a `jobID` that uniquely identifies your request.
+The response contains a int64 (`jobID`) that uniquely identifies your request.
 
 ### 2. Query Receipt Proof
 

--- a/docs/build/prove-api/prover-contract.md
+++ b/docs/build/prove-api/prover-contract.md
@@ -27,7 +27,7 @@ For applications validating specific events emitted by their contracts on a give
 Validates a cross-chain event from a counterparty chain and returns the event along with event identifiers. The function will revert if the validation fails.
 
 ```
-validateEvent(uint256 ,logIndex, bytes calldata proof) returns (bytes32 chainId, address emittingContract, bytes[] memory topics, bytes memory unindexedData)
+validateEvent(uint256 logIndex, bytes calldata proof) returns (bytes32 chainId, address emittingContract, bytes[] memory topics, bytes memory unindexedData)
 ```
 
 | Inputs           | Description           |


### PR DESCRIPTION
## Changes
- The `receipt_requestProof` API is returning the jobID directly in the `result` property
- Removed an extra comma in `validateEvent`