### PR TITLE
Update api-endpoints.mdx

### DIFF
--- a/docs/build/prove-api/api-endpoints.mdx
+++ b/docs/build/prove-api/api-endpoints.mdx
@@ -68,7 +68,7 @@ The response contains a `jobID` that uniquely identifies your request.
 #### Response Fields
 | Name                             | Description |
 | -------------------------------- | --------------------------- |
-| `jobID` _[uint64]_          | The jobID returned by the proof request. |
+| `jobID` _[int64]_          | The jobID returned by the proof request. |
 
 #### Response Body (Success)
 ```


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the API documentation for the "Query Receipt Proof" endpoint to reflect a change in the `jobID` response field type from `uint64` to `int64`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->