### PR TITLE
docs: fixed broken links

### DIFF
--- a/docs/build/examples/7683TheCompact.md
+++ b/docs/build/examples/7683TheCompact.md
@@ -18,7 +18,7 @@ This example will cover various components from different smart contracts that i
   - *Note*: TheCompact does not define the intent interface; this decision is left to the Arbiter.
   - *Reference*: [TheCompact GitHub](https://github.com/Uniswap/the-compact/blob/5a5b649ec39ab8f0e84289e6333df5960d6ed65a/src/TheCompact.sol)
 - **CrossL2Prover**: A contract developed by Polymer Protocol to validate cross-chain events without sending explicit messages. It stores the latest superRoot, which is the state of the Polymer rollup, enabling faster and more cost-effective Merkle proofs.
-  - *Reference*: [CrossL2Prover Docs](https://docs.polymerlabs.org/docs/build/prove-api/prover-contract)
+  - *Reference*: [CrossL2Prover Docs](https://docs.polymerlabs.org/docs/build/prove-api-v2/provercontract/)
 - **Arbiter**: The Arbiter contract is responsible for verifying and submitting settlement claims. It interacts with solvers to settle claims against TheCompact contract, acting as a bridge in the process.
   - *Reference*: [Arbiter Contract GitHub](https://github.com/polymerdao/arbiters/blob/bo/polyarbiter/src/PolymerArbiter.sol)
 - **Tribunal**: Tribunal provides a framework where settlement logic can be trusted and governed by signatures (via EIP-712 typed data). It is designed to handle cross-chain swap settlements, taking into account gas-price dynamics on priority gas auction (PGA) chains like Ethereum.

--- a/docs/build/faq.md
+++ b/docs/build/faq.md
@@ -55,7 +55,7 @@ This setup gives developers a **bird’s-eye view** of multiple rollups, allowin
 - There are no extra fees purely for generating the proof (beyond standard querying costs).
 
 > **Learn more**  
-> [Prover Contract Methods (Polymer Labs Docs)](https://docs.polymerlabs.org/docs/build/prove-api/prover-contract#methods)
+> [Prover Contract Methods (Polymer Labs Docs)](https://docs.polymerlabs.org/docs/build/prove-api-V2/proverContract#methods)
 
 ---
 


### PR DESCRIPTION
Hi! I updated outdated Polymer Labs documentation links that were returning 404 errors.
![image](https://github.com/user-attachments/assets/50934544-05ee-47d9-adad-404e8abdceba)


https://docs.polymerlabs.org/docs/build/prove-api/prover-contract
![image](https://github.com/user-attachments/assets/d67c6129-dfb5-4c96-90ae-779084496eb9)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the CrossL2Prover contract reference to the latest documentation version.
	- Revised the FAQ link for Prover Contract Methods to direct users to the updated API documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->