### PR TITLE
fix(docs): fix broken external links (404) in Key Network Information page

### DIFF
--- a/docs/build/start.mdx
+++ b/docs/build/start.mdx
@@ -54,11 +54,11 @@ import TabItem from '@theme/TabItem';
 | [Celo](https://docs.celo.org/network) | ✅ | ✅ | ~ 1sec |
 | [Mode](https://docs.mode.network/user-guides/network-details) | ✅ | ✅ | ~ 1sec |
 | [Mantle](https://docs.mantle.xyz/network/for-developers/resources-and-tooling/node-endpoints-and-providers) | ✅ | ✅ | ~ 1sec |
-| [BOB](https://docs.gobob.xyz/learn/user-guides/networks) | ✅ | ✅ | ~ 1sec |
+| [BOB](https://docs.gobob.xyz/docs/user-hub/networks) | ✅ | ✅ | ~ 1sec |
 | [Everclear](https://docs.everclear.org/resources/contracts/testnet) | ✅ | ✅ | ~ 1sec |
 | [Soneium](https://docs.soneium.org/docs/builders/overview) | ✅ | ✅ | ~ 1sec |
 | [World Chain](https://docs.world.org/world-chain/quick-start/info) | ✅ | ✅ | ~ 1sec |
-| [Zora](https://docs.zora.co/zora-network/network) | ✅ | ✅ | ~ 1sec |
+| [Zora](https://nft-docs.zora.co/zora-network/network) | ✅ | ✅ | ~ 1sec |
 | [Scroll](https://docs.scroll.io/en/developers/scroll-contracts/) | ✅ | ✅ | ~ 1sec |
 | [Linea](https://docs.linea.build/get-started/build/network-info) | ✅ | ✅ | ~ 1sec |
 | [Blast](https://docs.blast.io/building/network-information) | ✅ | ✅ | ~ 1sec |
@@ -73,7 +73,7 @@ import TabItem from '@theme/TabItem';
 | [Saakuru](https://explorer.saakuru.network/) | ❌ | ✅ | ~ 1sec |
 | [B Sqaured](https://docs.bsquared.network/for-developers/basic_information) | ❌ | ✅ | ~ 1sec |
 | [Manta Pacific](https://docs.manta.network/docs/manta-pacific/Build%20on%20Manta/Network%20Information) | ❌ | ✅ | ~ 1sec |
-| [B3 ](https://docs.b3.fun/mainnet) | ✅ | ❌ | ~ 1sec |
+| [B3 ](https://docs.b3.fun/protocol/network-setup) | ✅ | ❌ | ~ 1sec |
 | [ApeChain ](https://docs.apechain.com/metamask) | ✅ | ❌ | ~ 1sec |
 | [MegaETH ](https://docs.megaeth.com/) | ✅ | ❌ | ~ 1sec |
 | [Doma ](https://docs.d3.app/) | ✅ | ❌ | ~ 1sec |
@@ -88,7 +88,7 @@ import TabItem from '@theme/TabItem';
 | [Ethereum](https://ethereum.org/en/developers/docs/networks/) | ✅ | ✅ | ~ 120secs | 10 Blocks |
 | [Plasma](https://testnet.plasmascan.to/) | ✅ | ✅ | ~ 3secs | 3 Blocks |
 | [Arc](https://docs.arc.network/arc/references/connect-to-arc) | ✅ | ❌ | ~ 2secs | 2 Blocks |
-| [Berachain](https://docs.berachain.com/developers/network-configurations) | ✅ | ✅ | ~ 1sec | Single-slot |
+| [Berachain](https://docs.berachain.com/general/introduction/connect-to-berachain) | ✅ | ✅ | ~ 1sec | Single-slot |
 | [Sonic](https://docs.soniclabs.com/sonic/build-on-sonic/tooling-and-infra) | ✅ | ✅ | ~ 3secs | 2 Blocks |
 | [BSC](https://docs.bnbchain.org/bnb-smart-chain/developers/json_rpc/json-rpc-endpoint/#bsc-mainnet-chainid-0x38-56-in-decimal) | ✅ | ✅ | ~ 20secs | 12 Blocks |
 | [Avalanche](https://build.avax.network/docs/quick-start/networks/mainnet) | ✅ | ✅ | ~ 1sec | Single-slot |


### PR DESCRIPTION
## Problem
`docs/build/start.mdx` contains 4 broken external links returning 404.

## Root Cause
- BOB docs restructured from `/learn/user-guides/` to `/docs/user-hub/`
- Zora NFT docs migrated from `docs.zora.co` to `nft-docs.zora.co`
- B3 docs removed `/mainnet` page, network setup moved to `/protocol/network-setup`
- Berachain docs restructured from `/developers/network-configurations` to `/general/introduction/connect-to-berachain`

## Fix

**`docs/build/start.mdx`**
```diff
- [BOB](https://docs.gobob.xyz/learn/user-guides/networks)
+ [BOB](https://docs.gobob.xyz/docs/user-hub/networks)

- [Zora](https://docs.zora.co/zora-network/network)
+ [Zora](https://nft-docs.zora.co/zora-network/network)

- [B3 ](https://docs.b3.fun/mainnet)
+ [B3 ](https://docs.b3.fun/protocol/network-setup)

- [Berachain](https://docs.berachain.com/developers/network-configurations)
+ [Berachain](https://docs.berachain.com/general/introduction/connect-to-berachain)
```

## Verification
All target URLs confirmed working at time of PR submission.