### PR TITLE
fix(docs): correct misleading compute unit limit guidance in Solana client guide

### DIFF
--- a/docs/build/get started/prove-api-V2/SolanaProving/evmToSolanaClient.md
+++ b/docs/build/get started/prove-api-V2/SolanaProving/evmToSolanaClient.md
@@ -76,7 +76,7 @@ const addPriorityFee = anchor.web3.ComputeBudgetProgram.setComputeUnitPrice({
 
 | Common Errors | Description | Resolution |
 | --- | --- | --- |
-| `Exceeded compute units` | Not enough compute budget | Increase compute unit limit to at least 1.4M |
+| `Exceeded compute units` | Not enough compute budget | Set compute unit limit to 1.4M (Solana's per-transaction maximum) |
 | `Account not initialized` | Cache account doesn't exist | Call load_proof first to create it |
 | `AccountDiscriminatorMismatch` | Wrong account structure | Use correct PDA derivation |
 | `Missing return data` | CPI call failed | Ensure all accounts are passed correctly |


### PR DESCRIPTION
## Problem
In `evmToSolanaClient.md`, the "Common Errors" table for the validation step says:

> Increase compute unit limit to **at least** 1.4M

"At least 1.4M" implies 1.4M is a minimum, and that a higher value can be
requested if the error persists.

## Root Cause
1.4M CU is Solana's hard per-transaction compute unit cap
(`MAX_COMPUTE_UNIT_LIMIT`), not a recommended minimum. `SetComputeUnitLimit`
cannot exceed this value — any higher request is clamped to 1.4M by the
runtime. A developer following the current wording could waste time trying
to "increase the limit" beyond 1.4M when the only real fix is optimizing the
validation logic itself.

This also contradicts the code sample directly above in the same file, which
already sets `units: 1_400_000` as the value used — the table implies this is
a starting point that may need to go higher, when it's actually already at
the ceiling.

## Fix
**`docs/build/get started/prove-api-V2/SolanaProving/evmToSolanaClient.md`**

```diff
- | `Exceeded compute units` | Not enough compute budget | Increase compute unit limit to at least 1.4M |
+ | `Exceeded compute units` | Not enough compute budget | Set compute unit limit to 1.4M (Solana's per-transaction maximum) |
```

## Verification
Confirmed via Solana's official Compute Budget documentation, which states
the per-transaction CU limit is capped at 1,400,000 and cannot be exceeded:
- https://solana.com/docs/core/fees/compute-budget