### PR TITLE
docs: update prove-api V2 requests to the /v2/ endpoint

### DIFF
--- a/docs/build/get started/prove-api-V2/api-endpoints.mdx
+++ b/docs/build/get started/prove-api-V2/api-endpoints.mdx
@@ -9,9 +9,13 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import Admonition from '@theme/Admonition';
 
+<Admonition type="caution">
+**V2 proofs require V2 prover contracts.** Proofs returned by the `/v2/` endpoint (`evm_v2`, `svm_v2`) are not compatible with V1 prover contracts. If your application still uses V1 contracts, keep calling the `/v1/` endpoint.
+</Admonition>
+
 ### 1. Request Log Proof
 
-**Endpoint:** `api.polymer.zone/v1/`
+**Endpoint:** `api.polymer.zone/v2/`
 
 **Method:** `POST`
 
@@ -54,7 +58,7 @@ The parameters are now enclosed in a single object (instead of an array of separ
 {
   "jsonrpc": "2.0",
   "id": 1,
-  "result": jobID
+  "result": 12345
 }
 ```
 
@@ -68,7 +72,7 @@ The response contains a jobID that uniquely identifies your request.
 
 ### 2. Query Proof Status
 
-**Endpoint:** `api.polymer.zone/v1/`
+**Endpoint:** `api.polymer.zone/v2/`
 
 **Method:** `POST`
 
@@ -81,19 +85,28 @@ To query the status of a proof job, use the `proof_query` method:
   "jsonrpc": "2.0",
   "id": 1,
   "method": "proof_query",
-  "params": ["jobID"]
+  "params": [12345]
 }
 ```
 
 #### Response Body (Success)
 
-```json title="Complete Proof Response" {5-6}
+```json title="Complete Proof Response" {5-7}
 {
   "jsonrpc": "2.0",
   "id": 1,
   "result": {
     "status": "complete",
-    "proof": "base64EncodedProofData..."
+    "proofType": "evm_v2",
+    "proof": "base64EncodedProofData...",
+    "jobID": 12345,
+    "proofRequest": {
+      "srcChainId": 11155420,
+      "srcBlockNumber": 26421705,
+      "globalLogIndex": 15
+    },
+    "createdAt": 1708300800000,
+    "updatedAt": 1708300801000
   }
 }
 ```
@@ -102,8 +115,14 @@ To query the status of a proof job, use the `proof_query` method:
 
 | Parameter | Description |
 | -------------------------------- | --------------------------- |
-| `proof` | Base64 encoded bytes payload containing the IAVL proof of the application's log stored in the Polymer Rollup. |
-| `status` | Indicates the current status of the proof (`complete`, `error`, `pending`). |
+| `status` | Current status of the proof: `initialized`, `pending`, `complete`, `error`, or `not_found`. |
+| `proofType` | Proof generation version used. Requests to `/v2/` return `evm_v2` for EVM chains or `svm_v2` for Solana. |
+| `proof` | Base64 encoded bytes payload containing the IAVL proof of the application's log stored in the Polymer Rollup. Only present when `status` is `complete`. |
+| `jobID` | The jobID this response corresponds to. |
+| `proofRequest` | The original request parameters, echoed back for traceability. |
+| `createdAt` | Unix timestamp in milliseconds when the proof request was created. |
+| `updatedAt` | Unix timestamp in milliseconds when the job was last updated. |
+| `failureReason` | Reason the proof failed. Only present when `status` is `error`. |
 
 <Admonition type="info">
 **Proof Encoding**: Proof bytes are `base64` encoded. Your application must decode and convert to `hex` to pass as call data to the contract on-chain.
@@ -113,7 +132,7 @@ To query the status of a proof job, use the `proof_query` method:
 
 ```javascript title="Complete API Flow" {2,6-10,15,34,38,39,43}
 const response = await axios.post(
-  "https://api.polymer.zone/v1/",
+  "https://api.polymer.zone/v2/",
   {
     jsonrpc: "2.0",
     id: 1,
@@ -145,7 +164,7 @@ while (!proofResponse?.data?.result?.proof && attempts < maxAttempts) {
   await new Promise(resolve => setTimeout(resolve, 2000)); // Wait 2 seconds
   
   proofResponse = await axios.post(
-    "https://api.polymer.zone/v1/",
+    "https://api.polymer.zone/v2/",
     {
       jsonrpc: "2.0",
       id: 1,


### PR DESCRIPTION
Updates the Prove API Methods page under `prove-api-V2/` so the documented requests actually target the v2 API.

## Why

The page lives under `prove-api-V2/` but every request example pointed at `api.polymer.zone/v1/`, so anyone following it got v1 proofs (`evm_v1`/`svm_v1`) and the documented response was missing the fields v2 returns.

## Changes

- Endpoint changed from `api.polymer.zone/v1/` to `api.polymer.zone/v2/` in both method sections and both `axios.post` calls in the usage example.
- Query response example and field table now cover the full v2 shape: `proofType`, `jobID`, `proofRequest`, `createdAt`, `updatedAt`, `failureReason`.
- Status values corrected to `initialized`, `pending`, `complete`, `error`, `not_found` (previously listed only `complete`, `error`, `pending`).
- Added a caution callout that v2 proofs only work with V2 prover contracts, so V1 integrations should stay on `/v1/`.
- Fixed two invalid JSON placeholders: bare `jobID` as a result value, and the jobID passed as a quoted string in `proof_query` params (it is an int64).

Verified against `polymerdao/proof-api`:

- `rpc/versioned_router.go` - v2 is a URL prefix over the same JSON-RPC methods, enabled by default.
- `controller/polymer_controller.go` (`determineProofType`) - `apiVersion >= 2` yields `evm_v2`/`svm_v2`.
- `types/responses/v2response.go` and `models/proof_job.go` (`ToProofResponseV2`) - response fields and status values.
- Method names `proof_request`/`proof_query` confirmed unchanged in v2.

## Follow-ups not included here

- `docs/build/Release-notes.mdx` names the methods `prove_request`/`prove_query` and shows `"proof": "0x..."`. Both look wrong: the server registers `proof_request`/`proof_query`, and `Proof` is a `[]byte` so it marshals to base64.
- Several other pages still document the v1 endpoint (`start.mdx`, `portal.md`, `why polymer/simplified-devx.mdx`, `why polymer/PolymerAtaGlance.mdx`, `why polymer/examples/multi-rollup_apps.mdx`). Left alone since v1 remains supported.