### PR TITLE
fix(docs): remove broken Solana light client link

### DIFF
--- a/docs/build/get started/prove-api-V2/SolanaProving/solanaEVMProving.md
+++ b/docs/build/get started/prove-api-V2/SolanaProving/solanaEVMProving.md
@@ -8,7 +8,6 @@ sidebar_label: 'Proving Solana Logs on EVM'
 This guide will walk you through the process of proving and verifying Solana program logs on EVM chains using Polymer's state proof system. By following these steps, you'll be able to emit logs on Solana and then cryptographically verify them on any EVM chain.
 
 This Solana documentation section will follow this example: [solana-polymer-prover-cpi](https://github.com/dpbmaverick98/solana-polymer-prover-cpi/blob/main/programs/my_anchor_project/src/lib.rs)
-You can learn more about Solana Light Client Implementation: [Here](https://docs.polymerlabs.org/docs/category/solana-light-client-1)
 
 ### Overview
 


### PR DESCRIPTION
## Summary

Removes the broken Solana Light Client documentation link from the Solana-to-EVM proving guide.

## Why

The linked `solana-light-client-1` documentation page returns 404, and there is currently no confirmed replacement page. Removing the stale link avoids sending readers to a dead page while keeping the rest of the guide unchanged.

Fixes #359