### PR TITLE
docs: noindex non-production Netlify deploys

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -23,6 +23,13 @@ const config = {
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
 
+  // Keep non-production Netlify deploys out of search indexes. Netlify sets
+  // CONTEXT to 'production' | 'deploy-preview' | 'branch-deploy' | 'dev' at
+  // build time (undefined for local builds). Only production stays indexable;
+  // every other context gets <meta name="robots" content="noindex, nofollow">
+  // on every page, so branch/preview deploys can't surface stale docs in search.
+  noIndex: !!process.env.CONTEXT && process.env.CONTEXT !== 'production',
+
   // Even if you don't use internalization, you can use this field to set useful
   // metadata like html lang. For example, if your site is Chinese, you may want
   // to replace "en" with "zh-Hans".


### PR DESCRIPTION
## Why
Branch deploys and deploy previews are served on public `*.netlify.app` URLs with no `robots.txt`, so search engines can index them — surfacing stale docs to consumers. This makes only production indexable.

## Change
`docusaurus.config.js`: set `noIndex` based on Netlify's `CONTEXT` build var.
```js
noIndex: !!process.env.CONTEXT && process.env.CONTEXT !== 'production',
```
- `production` → indexable (unchanged)
- `deploy-preview` / `branch-deploy` → every page gets `<meta name="robots" content="noindex, nofollow">`
- local builds (`CONTEXT` undefined) → indexable, no behavior change

## Verification
- `CONTEXT=deploy-preview npm run build` → `noindex` present on all 37 pages
- `CONTEXT=production npm run build` → 0 pages with `noindex`

## Follow-ups (not in this PR, dashboard-side)
- Consider disabling/gating Netlify branch deploys & deploy previews outright.
- For URLs already indexed from old preview deploys, use Google Search Console removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)