### PR TITLE
docs: land on Build docs instead of splash homepage

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,42 +1,9 @@
 import React from 'react';
-import clsx from 'clsx';
-import Link from '@docusaurus/Link';
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
-import Layout from '@theme/Layout';
-import HomepageFeatures from '@site/src/components/HomepageFeatures';
-import FeatureList from '@site/src/components/featurelist';
+import {Redirect} from '@docusaurus/router';
 
-import styles from './index.module.css';
-
-function HomepageHeader() {
-  const {siteConfig} = useDocusaurusContext();
-  return (
-    <header className={clsx('hero hero--primary', styles.heroBanner)}>
-      <div className="container">
-        <h1 className="hero__title">{siteConfig.title}</h1>
-        <p className="hero__subtitle">{siteConfig.tagline}</p>
-        <div className={styles.buttons}>
-          <Link
-            className="button button--secondary button--lg"
-            to="/docs/build/start">
-            Get Started Quickly ⏱️
-          </Link>
-        </div>
-      </div>
-    </header>
-  );
-}
-
+// The site root redirects straight into the Build docs so visitors land in the
+// documentation instead of a near-empty splash page. This matches where the
+// "Build" navbar tab points (the first doc in the Build sidebar).
 export default function Home() {
-  const {siteConfig} = useDocusaurusContext();
-  return (
-      <Layout
-          title={`${siteConfig.title}`}
-          description="Explore Polymer - Make your contracts interoperable">
-          <HomepageHeader />
-          <main>
-              <HomepageFeatures list={FeatureList("docs")} />
-          </main>
-      </Layout>
-  );
+  return <Redirect to="/docs/build/start" />;
 }


### PR DESCRIPTION
## Problem
Opening the docs (`/`) dropped visitors on a near-empty splash page — just the title, tagline, and a single **"Get Started Quickly"** button (`src/pages/index.js`; the `HomepageFeatures`/`FeatureList` below renders nothing because `FeatureList` returns an empty array). To actually read the docs you had to then click the **Build** tab.

## Fix
Redirect the site root straight to `/docs/build/start` — the same destination the **Build** navbar tab points at — so opening the docs lands you in the Build section with no splash step.

```jsx
import {Redirect} from '@docusaurus/router';
export default function Home() {
  return <Redirect to="/docs/build/start" />;
}
```

## Verification
- `npm run build` passes with `onBrokenLinks: 'throw'`.
- The generated root `build/index.html` carries the redirect to `/docs/build/start`.

Note: the old `HomepageHeader`/`HomepageFeatures`/`featurelist` components are now unused but left in place; happy to delete them in a follow-up if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)