### PR TITLE
docs: add Learn section (About Polymer + per-API concept pages) [Phase 1/2]

### DIFF
--- a/docs/learn/about-polymer.mdx
+++ b/docs/learn/about-polymer.mdx
@@ -1,0 +1,31 @@
+---
+sidebar_position: 0
+sidebar_label: 'About Polymer'
+---
+
+# About Polymer
+
+**Polymer is an interoperability protocol.** It lets the contracts you already run act on what happens on other chains — either by *proving* a source event and verifying it yourself, or by having Polymer *prove and execute* on your behalf.
+
+## Two ways to use Polymer
+
+### Prove API — get a verifiable proof
+
+Request a signed attestation of an event that happened on a source chain, then verify it on-chain yourself with the [`CrossL2ProverV2`](<../build/get started/prove-api-V2/proverContract.mdx>) contract's `validateEvent`. You keep full control of destination execution.
+
+→ [How the Prove API works](./how-prove-api-works.mdx) · [Prove API reference](<../build/get started/prove-api-V2/api-endpoints.mdx>)
+
+### Execute API — let Polymer relay and execute
+
+Hand Polymer a destination call and it handles delivery: it *optionally* generates the proof, then its relayer submits an **arbitrary contract call** on the destination — managing the wallet, nonces, retries, and gas. Because the proof is optional, Execute can also drive **pure execution** flows that use no proof at all.
+
+→ [How the Execute API works](./how-execute-api-works.mdx) · [Execute API reference](<../build/get started/execute-api.mdx>)
+
+## One engine underneath
+
+Both APIs sit on the same proving engine: Polymer reads chain state from many independent sources, applies a per-chain finality threshold, reaches **m-of-n consensus**, and signs the result — so an attestation is trustworthy without any single source being trusted. See [How the Prove API works](./how-prove-api-works.mdx) for the details.
+
+## What Polymer powers
+
+- **Slippage-free USDC bridge (Circle CCTP v2).** Users move canonical USDC across chains with no slippage — a free ~20-minute slow path (CCTP v2 standard transfer) and a ~20-second fast path for 1 bps (CCTP v2 Fast Transfer). Polymer provides the **execution/relaying** via the Execute API so users never run their own relayer. This flow uses relaying only — no Prove API.
+- **Proving-based flows** — intent settlement, synced contract state, cross-chain governance, and more, where an action is proven on one chain and acted on elsewhere. See [Messaging vs Proofs](<../build/why polymer/interop-contract.mdx>).

--- a/docs/learn/how-execute-api-works.mdx
+++ b/docs/learn/how-execute-api-works.mdx
@@ -1,0 +1,42 @@
+---
+sidebar_position: 2
+sidebar_label: 'How the Execute API works'
+---
+
+# How the Execute API works
+
+The **Execute API** is how Polymer delivers a cross-chain call for you. Instead of generating a proof and submitting the destination transaction yourself (the [Prove API](./how-prove-api-works.mdx) flow), you hand Polymer a destination call and it runs the delivery end-to-end — **and the proof is optional**.
+
+## The flow
+
+1. **Submit an execute request.** You send an envelope with an optional `proofRequest` and an `executeRequest` describing the destination call: `destChainId`, `destContractAddress`, `methodSignature`, `args`, and `gasLimit`.
+2. **Polymer (optionally) proves.** If a `proofRequest` is present, Polymer generates the attestation with the same [proving engine](./how-prove-api-works.mdx) and substitutes it wherever you put the `$proof` placeholder in `args`.
+3. **Polymer relays and executes.** Its relayer submits the transaction on the destination chain — calling the method you specified with your arguments — and manages the wallet, nonces, retries, and gas.
+4. **You poll for the result** with `execute_query` to get the status and the destination `transactionHash`.
+
+→ [Execute API reference](<../build/get started/execute-api.mdx>)
+
+## Two modes
+
+### Prove + execute
+
+Include a `proofRequest` and reference the generated proof via `$proof` in your `args`. Polymer proves the source event, then calls your destination method with the proof inlined — one API call replaces "request proof → poll → submit transaction."
+
+### Pure execution (no proof)
+
+Omit `proofRequest` entirely and Polymer simply relays an **arbitrary destination call** for you. Nothing in this mode touches the proving engine.
+
+The flagship example is the **slippage-free USDC bridge on Circle CCTP v2**: Polymer uses pure execution to relay CCTP transfers, giving users a free ~20-minute path and a ~20-second fast path (1 bps) without running any relayer of their own. It uses none of Polymer's proofs — just the relaying.
+
+## What Polymer manages for you
+
+Polymer runs a dedicated wallet per partner and handles nonces, automatic retries, and gas, so a destination transaction lands in milliseconds without you operating any relayer infrastructure.
+
+:::info
+The Execute API is currently available to Polymer partners. Partners fund their dedicated wallet on each chain they execute on.
+:::
+
+## Execute vs Prove
+
+- Use the **Prove API** when you want to verify the proof yourself and keep control of destination execution.
+- Use the **Execute API** when you want Polymer to deliver — with a proof (prove + execute) or without one (pure execution / arbitrary calls).

--- a/docs/learn/how-prove-api-works.mdx
+++ b/docs/learn/how-prove-api-works.mdx
@@ -1,11 +1,11 @@
 ---
-sidebar_position: 4
-sidebar_label: 'How It Works'
+sidebar_position: 1
+sidebar_label: 'How the Prove API works'
 ---
 
-# How Polymer Works
+# How the Prove API works
 
-Polymer is a **cross-chain state oracle**: it reads chain state and events from many independent sources, reaches **m-of-n consensus** over what it read, and issues a **signed attestation** that any chain can verify. Applications request these attestations through the Prove API and verify them on-chain with the [Prover Contract](<../get started/prove-api-V2/proverContract.mdx>).
+The **Prove API** is how Polymer proves that something happened on another chain. Under the hood, the proving engine works like a **cross-chain state oracle**: it reads chain state and events from many independent sources, reaches **m-of-n consensus** over what it read, and issues a **signed attestation** that any chain can verify. You request these attestations through the Prove API and verify them on-chain with the [Prover Contract](<../build/get started/prove-api-V2/proverContract.mdx>). For the bigger picture — including relaying via the Execute API — see [About Polymer](./about-polymer.mdx).
 
 ## The pipeline
 
@@ -37,7 +37,7 @@ Once m of n agree, Polymer signs the agreed result. That signed attestation *is*
 
 ### 5. Verify on-chain
 
-The application submits the attestation to the [`CrossL2ProverV2`](<../get started/prove-api-V2/proverContract.mdx>) contract. `validateEvent(proof)` checks Polymer's signature and returns the decoded event — source chain, emitting contract, topics, and data — reverting if verification fails. The app runs no extra infrastructure.
+The application submits the attestation to the [`CrossL2ProverV2`](<../build/get started/prove-api-V2/proverContract.mdx>) contract. `validateEvent(proof)` checks Polymer's signature and returns the decoded event — source chain, emitting contract, topics, and data — reverting if verification fails. The app runs no extra infrastructure.
 
 ## Security model: m-of-n
 
@@ -51,7 +51,7 @@ Polymer's security is **m-of-n**: trust is distributed across `n` independent so
 
 ## Latency: finality dominates
 
-End-to-end proof time is dominated by the source chain's finality threshold, not by Polymer's own processing — consensus and signing complete in well under a second. See the per-chain latency and finality figures in [Key Network Information](../start.mdx).
+End-to-end proof time is dominated by the source chain's finality threshold, not by Polymer's own processing — consensus and signing complete in well under a second. See the per-chain latency and finality figures in [Key Network Information](../build/start.mdx).
 
 ## What this looks like for developers
 
@@ -61,4 +61,4 @@ From an application's point of view the flow stays simple:
 2. **Request** a proof (attestation) for that event via the Prove API.
 3. **Verify** it on the destination chain with `validateEvent` and act on the returned data.
 
-See [Simplified DevX](./simplified-devx.mdx) for the end-to-end code.
+See [Simplified DevX](<../build/why polymer/simplified-devx.mdx>) for the end-to-end code.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -80,10 +80,16 @@ const config = {
         items: [
            {
             type: 'docSidebar',
-            sidebarId: 'buildSidebar', 
-            label : 'Build', 
+            sidebarId: 'learnSidebar',
+            label : 'Learn',
             position: 'left'
-          },       
+          },
+           {
+            type: 'docSidebar',
+            sidebarId: 'buildSidebar',
+            label : 'Build',
+            position: 'left'
+          },
           {
             href: 'https://github.com/polymerdao',
             // label: 'GitHub',

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import {Redirect} from '@docusaurus/router';
 
-// The site root redirects straight into the Build docs so visitors land in the
-// documentation instead of a near-empty splash page. This matches where the
-// "Build" navbar tab points (the first doc in the Build sidebar).
+// The site root redirects into the docs so visitors land on content instead of
+// a near-empty splash page. Points at the Learn section's "About Polymer" so
+// new readers get the conceptual overview first.
 export default function Home() {
-  return <Redirect to="/docs/build/start" />;
+  return <Redirect to="/docs/learn/about-polymer" />;
 }


### PR DESCRIPTION
**Phase 1 of a 2-PR docs restructure.** This one is *additive and low-risk*: it introduces a **Learn** section and reframes the concept pages. All Build **reference** pages stay exactly where they are (stable URLs). Phase 2 will move the remaining conceptual pages + add redirects.

## Why
The docs were shaped around one capability — proving (Prove API). But Polymer is an **interoperability protocol** with two capabilities on one engine: **Prove API** (get an attestation, verify it yourself) and **Execute API** (Polymer relays + executes arbitrary destination calls, proof optional). The relaying side — including the CCTP USDC bridge — wasn't documented, and concepts were buried below the API reference.

## Changes
- **`learn/about-polymer.mdx`** (new) — leads with *"Polymer is an interoperability protocol"*; explains the two capabilities, the shared m-of-n engine, and what Polymer powers.
  - Flagship: a **slippage-free USDC bridge on Circle CCTP v2** (≈20 min free / ≈20 s at 1 bps), delivered via **Execute API relaying — no Prove API**.
- **`learn/how-prove-api-works.mdx`** (moved + reframed from `build/why polymer/how-it-works.mdx`) — "cross-chain state oracle" now describes the *proving mechanism*, not Polymer-the-product.
- **`learn/how-execute-api-works.mdx`** (new) — the relaying/execution flow; **pure execution (no proof)** as a first-class mode, with the CCTP USDC bridge as the example.
- **Navbar:** new **Learn** tab before Build (reuses the pre-existing `learnSidebar`).
- **Landing:** site root now redirects to `/docs/learn/about-polymer` (concept-first; supersedes the `/docs/build/start` target from #371, now merged).

## Naming
- Product descriptor = **"interoperability protocol"** (About Polymer only).
- **"cross-chain state oracle"** = proving mechanism only (How the Prove API works). Verified via grep.

## Verification
- `npm run build` passes with `onBrokenLinks: 'throw'`; all three Learn pages build and their cross-links resolve.

## Note / Phase 2 preview
There's intentional, temporary overlap between the new Learn pages and the still-in-place `why polymer/` pages (At A Glance, Simplified DevX, Messaging vs Proofs). **Phase 2** moves those into Learn, curates Build to pure reference, and adds `@docusaurus/plugin-client-redirects` for all moved URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)