### PR TITLE
docs: add client redirects for restructured URLs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -64,6 +64,24 @@ const config = {
     ],
   ],
 
+  plugins: [
+    [
+      '@docusaurus/plugin-client-redirects',
+      {
+        // Old URLs from the Learn/Build restructure -> current locations.
+        redirects: [
+          { from: '/docs/build/why polymer/how-it-works', to: '/docs/learn/how-prove-api-works' },
+          { from: '/docs/build/why polymer/interop-contract', to: '/docs/learn/messaging-vs-proofs' },
+          { from: '/docs/build/why polymer/simplified-devx', to: '/docs/build/get started/quickstart' },
+          { from: '/docs/build/why polymer/PolymerAtaGlance', to: '/docs/learn/about-polymer' },
+          { from: '/docs/build/why polymer/examples/simple-key-value-app', to: '/docs/build/examples/simple-key-value-app' },
+          { from: '/docs/build/why polymer/examples/multi-rollup_apps', to: '/docs/build/examples/simple-key-value-app' },
+          { from: '/docs/build/why polymer/examples/chain_abstraction', to: '/docs/build/examples/chain_abstraction' },
+        ],
+      },
+    ],
+  ],
+
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@docusaurus/core": "3.2.1",
+        "@docusaurus/plugin-client-redirects": "^3.2.1",
         "@docusaurus/preset-classic": "3.2.1",
         "@mdx-js/react": "^3.0.0",
         "@metamask/docusaurus-openrpc": "^0.4.1",
@@ -2300,6 +2301,30 @@
       "peerDependencies": {
         "react": "*",
         "react-dom": "*"
+      }
+    },
+    "node_modules/@docusaurus/plugin-client-redirects": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-3.2.1.tgz",
+      "integrity": "sha512-GgzuqwbqNQSP5s/ouUrOQFuHI8m4Rn8a5CHuWkwpqj+5lbQMsABcvsoiWjrH9M00CzN48q+slSbJy7rtHjn7zg==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/core": "3.2.1",
+        "@docusaurus/logger": "3.2.1",
+        "@docusaurus/utils": "3.2.1",
+        "@docusaurus/utils-common": "3.2.1",
+        "@docusaurus/utils-validation": "3.2.1",
+        "eta": "^2.2.0",
+        "fs-extra": "^11.1.1",
+        "lodash": "^4.17.21",
+        "tslib": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=18.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@docusaurus/core": "3.2.1",
+    "@docusaurus/plugin-client-redirects": "^3.2.1",
     "@docusaurus/preset-classic": "3.2.1",
     "@mdx-js/react": "^3.0.0",
     "@metamask/docusaurus-openrpc": "^0.4.1",


### PR DESCRIPTION
Now that the Learn/Build split is live (#373, #374), this maps the old URLs to their current locations so external links, bookmarks, and search results don't 404. (This is the follow-up we deferred from PR2.)

## Changes
- Add **`@docusaurus/plugin-client-redirects`** (pinned to core 3.2.1).
- Redirect every moved/renamed page:

| Old URL | New URL |
|---|---|
| `.../why polymer/how-it-works` | `.../learn/how-prove-api-works` |
| `.../why polymer/interop-contract` | `.../learn/messaging-vs-proofs` |
| `.../why polymer/simplified-devx` | `.../get started/quickstart` |
| `.../why polymer/PolymerAtaGlance` | `.../learn/about-polymer` |
| `.../why polymer/examples/simple-key-value-app` | `.../examples/simple-key-value-app` |
| `.../why polymer/examples/multi-rollup_apps` (legacy) | `.../examples/simple-key-value-app` |
| `.../why polymer/examples/chain_abstraction` | `.../examples/chain_abstraction` |

## Verification
`npm run build` passes; each old path now emits a redirect page with a `meta http-equiv="refresh"` + `canonical` pointing at the new URL (spaces `%20`-encoded, e.g. `/docs/build/get%20started/quickstart`).

Note: pure deletions from earlier cleanup (`7683TheCompact`, `intentbatches`) are intentionally not redirected — no equivalent destination. Say the word if you'd like them pointed at the Examples index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)