### PR TITLE
docs: drop "the" from the two API sidebar labels

### DIFF
--- a/docs/build/learn/how-execute-api-works.mdx
+++ b/docs/build/learn/how-execute-api-works.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 2
-sidebar_label: 'How the Execute API works'
+sidebar_label: 'How Execute API works'
 ---
 
 # How the Execute API works

--- a/docs/build/learn/how-prove-api-works.mdx
+++ b/docs/build/learn/how-prove-api-works.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 1
-sidebar_label: 'How the Prove API works'
+sidebar_label: 'How Prove API works'
 ---
 
 # How the Prove API works


### PR DESCRIPTION
Follow-up to #376. Two-line change to the Learn sidebar labels.

| before | after |
| --- | --- |
| How the Prove API works | How Prove API works |
| How the Execute API works | How Execute API works |

Sidebar under Build → Learn now reads:

```
Learn
├── About Polymer
├── How Prove API works
├── How Execute API works
└── Messaging Vs Proofs
```

Only `sidebar_label` changed. The page `# H1` headings and the prose cross-links in `about-polymer.mdx` still read "How the … API works" — a shorter nav label than page title is what `sidebar_label` is for, but happy to sync those too if you'd rather they match.

`npm run build` passes clean and the labels render as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)