### PR TITLE
docs: restructure Learn around what it is, how to choose, and what to trust

### DIFF
--- a/docs/build/learn/about-polymer.mdx
+++ b/docs/build/learn/about-polymer.mdx
@@ -7,27 +7,48 @@ sidebar_label: 'About Polymer'
 
 **Polymer is an interoperability protocol.** It lets the contracts you already run act on what happens on other chains — either by *proving* a source event and verifying it yourself, or by having Polymer *prove and execute* on your behalf.
 
+Nothing about your source contract has to change. You emit a standard event; Polymer proves it happened.
+
 ## Two ways to use Polymer
 
 ### Prove API — get a verifiable proof
 
 Request a signed attestation of an event that happened on a source chain, then verify it on-chain yourself with the [`CrossL2ProverV2`](<../get started/prove-api-V2/proverContract.mdx>) contract's `validateEvent`. You keep full control of destination execution.
 
-→ [How the Prove API works](./how-prove-api-works.mdx) · [Prove API reference](<../get started/prove-api-V2/api-endpoints.mdx>)
+→ [How Prove API works](./how-prove-api-works.mdx) · [Prove API reference](<../get started/prove-api-V2/api-endpoints.mdx>)
 
 ### Execute API — let Polymer relay and execute
 
 Hand Polymer a destination call and it handles delivery: it *optionally* generates the proof, then its relayer submits an **arbitrary contract call** on the destination — managing the wallet, nonces, retries, and gas. Because the proof is optional, Execute can also drive **pure execution** flows that use no proof at all.
 
-→ [How the Execute API works](./how-execute-api-works.mdx) · [Execute API reference](<../get started/execute-api.mdx>)
+Execute API is currently available to Polymer partners.
+
+→ [How Execute API works](./how-execute-api-works.mdx) · [Execute API reference](<../get started/execute-api.mdx>)
+
+Not sure which one you need? See [Choosing an API](./choosing-an-api.mdx).
 
 ## One engine underneath
 
-Both APIs sit on the same proving engine: Polymer reads chain state from many independent sources, applies a per-chain finality threshold, reaches **m-of-n consensus**, and signs the result — so an attestation is trustworthy without any single source being trusted. See [How the Prove API works](./how-prove-api-works.mdx) for the details.
+Both APIs sit on the same proving engine: Polymer reads chain state from many independent sources, applies a per-chain finality threshold, reaches m-of-n consensus, and signs the result — so an attestation is trustworthy without any single source being trusted.
+
+→ [How Prove API works](./how-prove-api-works.mdx) for the mechanism · [Trust model](./trust-model.mdx) for what you are trusting and what you still have to check
 
 ## What Polymer powers
 
-Each of these flagships has already processed over **$1.5 billion** in volume.
+Each of these flagships has processed over **$1.5 billion** in cumulative volume.
 
 - **Slippage-free USDC bridge (Circle CCTP v2) — the flagship Execute API use case.** Users move canonical USDC across chains with no slippage — a free ~20-minute slow path (CCTP v2 standard transfer) and a ~20-second fast path for 1 bps (CCTP v2 Fast Transfer). Polymer provides the **execution/relaying** via the Execute API so users never run their own relayer. This flow uses relaying only — no Prove API.
-- **Open Intents Framework (OIF) — the flagship Prove API use case.** The Prove API powers OIF and runs in production for **LI.FI** intents and their solver network: a solver's fill on one chain is proven and used to settle and repay on another. It also powers synced contract state, cross-chain governance, and similar prove-and-act flows. See [Messaging vs Proofs](./messaging-vs-proofs.mdx).
+- **Open Intents Framework (OIF) — the flagship Prove API use case.** The Prove API powers OIF and runs in production for intent protocols and their solver networks: a solver's fill on one chain is proven and used to settle and repay on another. It also powers synced contract state, cross-chain governance, and similar prove-and-act flows.
+
+→ [Use cases](./use-cases.mdx) for the full set of patterns Polymer supports
+
+## Where to go next
+
+| If you want to | Read |
+| --- | --- |
+| Understand why proofs beat messaging for this | [Proofs vs messaging](./messaging-vs-proofs.mdx) |
+| Pick between the two APIs | [Choosing an API](./choosing-an-api.mdx) |
+| See how a proof is produced and verified | [How Prove API works](./how-prove-api-works.mdx) |
+| Know what you are trusting | [Trust model](./trust-model.mdx) |
+| Write code now | [Quickstart](<../get started/quickstart.mdx>) |
+| Get an API key | [Onboard account](<../get started/portal.md>) |

--- a/docs/build/learn/choosing-an-api.mdx
+++ b/docs/build/learn/choosing-an-api.mdx
@@ -1,0 +1,59 @@
+---
+sidebar_position: 2
+sidebar_label: 'Choosing an API'
+---
+
+# Choosing an API
+
+Polymer exposes two APIs over one proving engine. The decision is about **who submits the destination transaction** — you, or Polymer.
+
+| | Prove API | Execute API |
+| --- | --- | --- |
+| Who generates the proof | Polymer, on request | Polymer, as part of the call — or not at all |
+| Who submits the destination transaction | You (or anyone) | Polymer's relayer |
+| Who pays destination gas | Whoever submits | Your partner wallet, funded per chain |
+| Who validates the event | Your destination contract | Your destination contract |
+| Relayer infrastructure to operate | None, if you submit on demand | None |
+| Wallet, nonce and retry management | Yours | Polymer's |
+| Works without a proof | No | Yes — pure execution |
+| Availability | Generally available | Polymer partners |
+
+Both paths call `validateEvent` on the destination and both require your contract to validate what comes back. Execute API changes who *delivers* the proof, not who *checks* it.
+
+## Use Prove API when
+
+- You want to hold the proof and decide when and where to use it.
+- Someone other than you submits the destination transaction — a solver, a keeper, or the end user.
+- You want one source event settled on several destinations, on your own schedule.
+- You would rather not depend on a third party for liveness of the destination call.
+
+→ [How Prove API works](./how-prove-api-works.mdx) · [Quickstart](<../get started/quickstart.mdx>)
+
+## Use Execute API when
+
+- You want one API call to cover proving *and* the destination transaction.
+- You do not want to run a relayer, manage nonces, or handle retries and gas.
+- You need the destination call to land fast and predictably without your own submission path.
+
+→ [How Execute API works](./how-execute-api-works.mdx) · [Execute API reference](<../get started/execute-api.mdx>)
+
+## Pure execution: Execute API with no proof
+
+Omit `proofRequest` and Execute API becomes a relayer for an arbitrary destination call. Nothing touches the proving engine. This is how Polymer relays canonical bridge transfers on behalf of users who do not want to operate submission infrastructure.
+
+Reach for this when the thing you need is delivery, not verification.
+
+## The integration, either way
+
+1. **Emit** a standard event from your contract on the source chain.
+2. **Obtain a proof** — request it yourself via Prove API, or let Execute API generate it inline.
+3. **Validate** on the destination: call `validateEvent`, then check the source chain, the emitting contract, the event signature, and replay protection.
+4. **Act** on the decoded event.
+
+Step 3 is where integrations go wrong. Read [Prover Integration](<../get started/prove-api-V2/decodingProverReturn.mdx>) before you ship it.
+
+## Next
+
+- [Trust model](./trust-model.mdx) — what an attestation does and does not guarantee
+- [Key network information](../start.mdx) — endpoints, contract addresses, supported chains
+- [Onboard account](<../get started/portal.md>) — get an API key

--- a/docs/build/learn/how-execute-api-works.mdx
+++ b/docs/build/learn/how-execute-api-works.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 4
 sidebar_label: 'How Execute API works'
 ---
 
@@ -36,7 +36,14 @@ Polymer runs a dedicated wallet per partner and handles nonces, automatic retrie
 The Execute API is currently available to Polymer partners. Partners fund their dedicated wallet on each chain they execute on.
 :::
 
-## Execute vs Prove
+## Still your job
 
-- Use the **Prove API** when you want to verify the proof yourself and keep control of destination execution.
-- Use the **Execute API** when you want Polymer to deliver — with a proof (prove + execute) or without one (pure execution / arbitrary calls).
+Execute API changes who submits the destination transaction. It does not change what your destination contract has to verify: the source chain, the emitting contract, the event signature, the topics length, and replay protection are all still yours to check on the decoded event.
+
+→ [Prover Integration](<../get started/prove-api-V2/decodingProverReturn.mdx>) · [Trust model](./trust-model.mdx)
+
+## Next
+
+- [Choosing an API](./choosing-an-api.mdx) — Prove or Execute, side by side
+- [Execute API reference](<../get started/execute-api.mdx>) — methods, parameters and responses
+- [Use cases](./use-cases.mdx) — what people build with pure execution

--- a/docs/build/learn/how-prove-api-works.mdx
+++ b/docs/build/learn/how-prove-api-works.mdx
@@ -1,11 +1,11 @@
 ---
-sidebar_position: 1
+sidebar_position: 3
 sidebar_label: 'How Prove API works'
 ---
 
 # How Prove API works
 
-**Prove API** is how Polymer proves that something happened on another chain. The proving engine reads chain state and events from many independent sources, reaches m-of-n consensus over what it read, and issues a signed attestation that any chain can verify. You request these attestations through the Prove API and verify them on-chain with the [Prover Contract](<../get started/prove-api-V2/proverContract.mdx>). For the bigger picture — including relaying via the Execute API — see [About Polymer](./about-polymer.mdx).
+**Prove API** is how Polymer proves that something happened on another chain. The proving engine reads chain state and events from many independent sources, reaches m-of-n consensus over what it read, and issues a signed attestation that any chain can verify. You request these attestations through the Prove API and verify them on-chain with the [Prover Contract](<../get started/prove-api-V2/proverContract.mdx>). For the bigger picture — including relaying via the Execute API — see [About Polymer](./about-polymer.mdx). For what an attestation does and does not guarantee, see [Trust model](./trust-model.mdx).
 
 ## The pipeline
 
@@ -49,6 +49,8 @@ Polymer's security is **m-of-n**: trust is distributed across `n` independent so
 - **Liveness by redundancy** — upstreams beyond the m-of-n minimum keep proofs flowing even if some sources lag or go offline.
 - **Independently checkable** — the attested state can be re-verified against public RPCs at the given block height.
 
+[Trust model](./trust-model.mdx) covers this in full: what the destination contract actually verifies, how liveness and safety failures differ, and the five checks your own contract still has to perform.
+
 ## Latency: finality dominates
 
 End-to-end proof time is dominated by the source chain's finality threshold, not by Polymer's own processing — consensus and signing complete in well under a second. See the per-chain latency and finality figures in [Key Network Information](../start.mdx).
@@ -61,4 +63,4 @@ From an application's point of view the flow stays simple:
 2. **Request** a proof (attestation) for that event via the Prove API.
 3. **Verify** it on the destination chain with `validateEvent` and act on the returned data.
 
-See the [Quickstart](<../get started/quickstart.mdx>) for the end-to-end code.
+See the [Quickstart](<../get started/quickstart.mdx>) for the end-to-end code, and [Prover Integration](<../get started/prove-api-V2/decodingProverReturn.mdx>) for the validation your destination contract must perform on the decoded event.

--- a/docs/build/learn/messaging-vs-proofs.mdx
+++ b/docs/build/learn/messaging-vs-proofs.mdx
@@ -1,102 +1,84 @@
 ---
-sidebar_position: 3
-sidebar_label: 'Messaging Vs Proofs'
+sidebar_position: 1
+sidebar_label: 'Proofs vs Messaging'
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-import Admonition from '@theme/Admonition';
+# Proofs vs messaging
 
-# Why Devs Choose Polymer
+Most cross-chain systems are **messaging** systems: you hand a bridge a payload on chain A and it delivers that payload to a contract you deployed on chain B. Polymer is a **proving** system: you emit an ordinary event on chain A, and anyone can obtain a signed attestation that the event happened and hand it to a contract on chain B.
 
-With Polymer, we enable the smart contracts you already use to be crosschain—a simpler, more flexible way to build multi-chain applications that puts developers first.
+The difference sounds small. It changes what you build, how many contracts you deploy, and what happens when you add a chain.
 
+## What you build with each
 
-<Admonition type="tip">
-With Polymer, developers can now treat interoperability as a byproduct of execution within their application contracts— not a separate architecture to manage.
-</Admonition>
+```text
+  Messaging                              Proving
+  ┌──────────────────────┐               ┌──────────────────────┐
+  │ your app contract    │               │ your app contract    │
+  │  + bridge interface  │               │  (emit an event)     │
+  │  + payload encoding  │               └──────────┬───────────┘
+  │  + fee estimation    │                          │ standard log
+  └──────────┬───────────┘                          ▼
+             │ configured route            ┌──────────────────────┐
+             ▼                             │  Prove API           │
+  ┌──────────────────────┐                 │  → signed attestation│
+  │ bridge / gateway     │                 └──────────┬───────────┘
+  └──────────┬───────────┘                            │ any destination
+             ▼                                        ▼
+  ┌──────────────────────┐               ┌──────────────────────┐
+  │ your dest. contract  │               │ your dest. contract  │
+  │  + bridge interface  │               │  validateEvent(proof)│
+  │  + payload decoding  │               └──────────────────────┘
+  └──────────────────────┘
+```
 
-<Tabs>
-  <TabItem value="traditional" label="Traditional Approach">
-    ## Outdated Messaging
+| | Messaging | Proving with Polymer |
+| --- | --- | --- |
+| Source contract | Implements the bridge's send interface | Emits a standard event, unchanged |
+| Destination contract | Implements the bridge's receive interface | Calls `validateEvent` once |
+| Routes | Configured per source/destination pair | None — prove any supported chain to any other |
+| Adding a chain | Redeploy and reconfigure existing instances | Nothing to change |
+| Payload | Application logic encoded into a bridge payload | The event keeps the shape you defined |
+| Who can deliver | The bridge's relayer set | Anyone holding a valid proof |
+| Fee model | Estimated on-chain at send time | Proof requested off-chain; destination pays gas |
 
-    ![Traditional messaging approach diagram](https://github.com/user-attachments/assets/0c5ea318-be74-4c9d-8f76-392b3097e20a)
+## Why the shape matters
 
-    This approach involves:
+**Emit once, prove anywhere.** A messaging send commits to a destination at the moment you send it. An event commits to nothing — you can request proofs for it later, for one destination or five, and decide after the fact. Adding a sixth chain does not touch the contract that emitted the event.
 
-    - Deploying source and destination contracts for every chain pair.
-    - Integrating bridge-specific logic and OApp/gateway contracts.
-    - Encoding application logic into payloads executed by the bridge.
-    - Managing on-chain fee estimation using external oracles.
-    - Parsing and executing data as dictated by the bridge protocol.
+**No bridge interface in your contract.** Because Polymer proves emitted logs rather than accepting payloads, your source contract has no cross-chain code in it at all. That removes a class of upgrade coupling: your app logic and your interoperability layer stop sharing a contract.
 
-    ### Drawbacks
+**The event stays yours.** With messaging, the wire format is the bridge's; you encode into it and decode out of it. With proofs, `validateEvent` hands back the source chain, the emitting contract, the topics, and the unindexed data of the event you already defined.
 
-    - **High engineering cost** — weeks or even months to implement and debug.
-    - **Single-source-to-single-destination limitation** — additional chains require more messages and more gas.
-    - **Infra overhead** — fees estimations by bridges often exceed 10x of execution costs.
-        - LZ typical fee: ~$0.30
-        - HL typical fee: ~$1.0
-    - **Manual reconfiguration** — adding new chains requires bridge updates on all existing instances.
-  </TabItem>
-  
-  <TabItem value="polymer" label="Polymer Approach">
-    ## Natively Interoperable Apps (Phat Apps)
+**Adding a chain is a Polymer-side change.** Support for a new chain means Polymer starts reading it. Your deployed contracts do not learn about it.
 
-    ![Polymer approach diagram](https://github.com/user-attachments/assets/54e41d66-1cb3-46b1-a0b6-accd32b3a7eb)
+## What proving asks of you instead
 
-    - **No contract interfaces needed** — emit standard application events.
-        - Polymer supports **state-level proofs**, which allows proving any emitted event without requiring special contracts on the origin chain.
-    - **Single proof call** — execute your destination logic using `validateEvent` with proof from Prove API.
-        - Polymer e2e latency is close to rollup block times i.e 2-4secs.
-    - **App defined API** — events retain their original format defined by the app developers.
-        - Proof validation is hyper efficient with on-chain gas costs of under a cent.
-    - **Custom logic control** — execute your app-specific validations before processing.
+Proving is not free of obligations — it moves them. Messaging systems decide for you who may deliver a message and hand your contract a payload they consider trusted. Polymer hands your contract a proof and expects your contract to decide whether it likes it.
 
-    ### Benefits of interoperable contracts 
+Concretely, a destination contract must check for itself:
 
-    - **Developer simplicity** — build faster, focus on core app logic.
-    - **Broadcast model** — emit once, prove anywhere.
-    - **No cross-chain boilerplate** — no need to re-configure contracts for every new chain.
-    - **Scalability** — as long as your contracts are deterministic, they are future-ready.
-    - **Permissionless Execution** — Anyone can submit a valid proof to trigger execution.
-        - For enterprise security, additional access control layers can be implemented.
-  </TabItem>
-</Tabs>
+- that the source chain is one you accept,
+- that the emitting contract is one you authorise,
+- that the event signature is the event you meant to handle,
+- that you have not processed this event before.
 
-## Use Cases
+Skipping any of these is exploitable. Anyone can submit a valid proof — that is the point of permissionless execution, and it is also why the validation lives in your contract.
 
-<Tabs>
-  <TabItem value="prove-actions" label="✅ Prove Actions">
-    ### Prove Actions Across Chains
+:::warning
+These checks are not optional. [Prover Integration](<../get started/prove-api-V2/decodingProverReturn.mdx>) walks through each one with code, and the [Trust model](./trust-model.mdx) explains why each exists.
+:::
 
-    - **Intent Settlement:** Prove that a user fill occurred (e.g., trade executed) before repaying solvers on the origin chain  (e.g., Eco, Catalyst).
-    - **Solver-Based Zaps:** Execute user-defined logic (like swaps or vault entry) fronted by solvers and proven via user-signed calldata (more fun with ERC-7702 and AI agents).
-    - **Decentralized Governance:** Enable token holders to vote on any chain and prove outcomes back to Ethereum for canonical result aggregation.
-  </TabItem>
+## When messaging is the better fit
 
-  <TabItem value="synced-state" label="🔁 Synced State">
-    ### Synced Contract State
+Be honest about the boundary:
 
-    - **Lending Protocols:** Synchronize key yield-impacting events across chains to maintain consistent APY (e.g., RiftLend).
-    - **Yield Aggregators:** Consolidate yield across multiple chains into a single APY representation  (e.g., Superform) or expand from a single chain to others.
-    - **Treasury Sync:** Use for stablecoins or structured products to relay yield/treasury info to all chains without infrastructure duplication.
-  </TabItem>
+- **You need the destination call to be atomic with the source call.** Proving is asynchronous by construction — the source event must reach finality before an attestation exists.
+- **You want a single vendor to own delivery end-to-end and you do not want to write destination validation.** Polymer's [Execute API](./how-execute-api-works.mdx) covers the delivery half of this, but the destination-side validation is still yours.
+- **You are moving value along a canonical path that already has a native bridge.** Prove what happened; do not re-implement the bridge.
 
-  <TabItem value="build-once" label="🌍 Build Once">
-    ### Build Once, Ship Everywhere
+## Next
 
-    - **Oracle Feeds:** Serve data from a central chain and allow anyone to fetch and prove values on demand in seconds and control your own bottomline—without high messaging fees.
-    - **Optimistic Oracles:** Replace bridge-dependent deployments with single-chain proofs—e.g., proving UMA predictions across 100 chains without extra dev work.
-    - **Stablecoin Extensions:** Sync yield or treasury status without replicating backends across rollups.
-  </TabItem>
-
-  <TabItem value="advanced" label="🧑🏻‍💻 Advanced">
-    ### Advanced Use Cases
-
-    - **Batched Intent Settlement:** Prove multiple user intents in one go, drastically reducing settlement overhead for solvers.
-    - **Multi-Source Solving:** Aggregate funds from multiple chains to fulfill a single user operation and pay solver back on all chains with a single proof. (e.g., Resource-lock management in OneBalance)
-    - **Stringed Transactions:** Execute chain-dependent workflows (swap on A → swap on B → fallback to A if slippage fails) with proof-verified checkpoints. (e.g., Composability stack by Biconomy)
-    - **Modular Execution:** Offload compute-heavy matching or auctions to optimized chains (e.g., gather orders on Base, match on Solana, settle back on Base).  (e.g., Everclear)
-  </TabItem>
-</Tabs> 
+- [Choosing an API](./choosing-an-api.mdx) — Prove or Execute
+- [Use cases](./use-cases.mdx) — the patterns this shape unlocks
+- [Quickstart](<../get started/quickstart.mdx>) — the four-step integration

--- a/docs/build/learn/trust-model.mdx
+++ b/docs/build/learn/trust-model.mdx
@@ -1,0 +1,73 @@
+---
+sidebar_position: 5
+sidebar_label: 'Trust Model'
+---
+
+# Trust model
+
+Before you route value through Polymer, it is worth being precise about what an attestation is, what it guarantees, and what it leaves to you.
+
+## What you are trusting
+
+An attestation is **Polymer's signature over a claim about another chain's state**. It says: reading chain X at height H, this log existed, at this position, emitted by this contract.
+
+That claim is produced by agreement, not by a validity proof:
+
+1. Polymer reads the source chain from a deliberately diverse set of upstreams — RPC endpoints from different providers, data from a chain's sequencer, trusted execution environments, and nodes Polymer runs itself.
+2. It waits for the source chain to reach a per-chain finality threshold.
+3. It requires **m of n** of those independent sources to agree on what they read.
+4. It signs the agreed result.
+
+So the trust assumption is: **no set of m sources is simultaneously wrong or colluding.** No single provider — including Polymer's own nodes — can produce an attestation alone.
+
+## What the destination contract actually checks
+
+This is the part most often misread. `validateEvent` verifies **Polymer's signature** over the attestation and returns the decoded event, reverting if the signature does not check out.
+
+It does **not** re-verify the source chain's consensus on-chain. There is no light client and no validity proof being checked by the destination contract. The security of an attestation rests on the m-of-n agreement behind it, and the destination contract's job is to confirm that Polymer signed it.
+
+That is a deliberate trade: it is what makes verification cost a fraction of a cent and work identically on every supported chain, including chains that could never run a light client for the source.
+
+## Failure modes, separated
+
+Distinguishing these two matters, because the mitigations are unrelated.
+
+**Liveness — proofs stop flowing.** Polymer maintains more upstreams than the minimum needed to reach consensus, so a single slow or unavailable provider does not block progress. There is no liveness dependency on any one source. The visible symptom is latency or a `pending` job, not a wrong answer.
+
+**Safety — a wrong claim gets signed.** This requires at least m independent sources to report the same incorrect state. Deeper finality thresholds raise the cost of the source-chain reorganisations that could cause honest sources to agree on state that is later undone, which is why the threshold is tuned per chain rather than set globally.
+
+You can also check Polymer's work after the fact. `inspectPolymerState` returns the attested state root, the block height it corresponds to, and the signature — enough to query a public RPC at that height and confirm the attested state matches what the chain actually holds.
+
+→ [Prover Contract](<../get started/prove-api-V2/proverContract.mdx>) for the inspection methods
+
+## What Polymer does not do for you
+
+An attestation proves that an event happened. It says nothing about whether *your* contract should act on it. Polymer will happily prove an event emitted by an attacker's contract, on a chain you never intended to accept, that you have already processed — because all three of those things did, in fact, happen.
+
+Your destination contract must therefore check:
+
+| Check | Why | If you skip it |
+| --- | --- | --- |
+| Source chain is one you accept | Events exist on every supported chain | An event from an unintended chain is treated as canonical |
+| Emitting contract is one you authorise | Anyone can deploy a contract that emits your event shape | An attacker's contract spoofs your events with arbitrary data |
+| Event signature matches exactly | Different parameter types hash differently | A similar event decodes into corrupted values |
+| Topics length is what you expect | Length affects how unindexed data parses | Arbitrary-length topics distort decoding |
+| The event has not been processed before | Proofs are not unique per submission and anyone may submit | The same event is replayed for duplicate effect |
+
+:::danger
+These are not defence-in-depth niceties; each one is load-bearing. [Prover Integration](<../get started/prove-api-V2/decodingProverReturn.mdx>) implements all five with code you can copy.
+:::
+
+Note in particular that a proof is **not** a unique identifier. Do not use it as your replay key — derive the key from the event's own data.
+
+## Permissionless execution is a property, not an accident
+
+Anyone holding a valid proof can submit it. That is what allows solvers, keepers and end users to drive your destination logic without being whitelisted, and it is why one source event can settle on many chains without you operating anything.
+
+It also means your destination function is publicly callable with attacker-chosen timing. If your application needs a narrower set of submitters, add that access control yourself — the proof system will not do it for you.
+
+## Next
+
+- [Prover Integration](<../get started/prove-api-V2/decodingProverReturn.mdx>) — the five checks, with code
+- [How Prove API works](./how-prove-api-works.mdx) — the pipeline in detail
+- [Key network information](../start.mdx) — per-chain finality thresholds and latency

--- a/docs/build/learn/use-cases.mdx
+++ b/docs/build/learn/use-cases.mdx
@@ -1,0 +1,70 @@
+---
+sidebar_position: 6
+sidebar_label: 'Use Cases'
+---
+
+# Use cases
+
+Patterns Polymer is used for in production, grouped by what they ask of the protocol. Each group notes which API it needs and where the relevant guide is.
+
+## Prove actions across chains
+
+Prove that something *happened* on one chain, then act on it somewhere else. Needs **Prove API**.
+
+- **Intent settlement** — prove that a solver's fill occurred on the destination chain before releasing or repaying on the origin chain. The proof is what makes the repayment safe to automate.
+- **Batched intent settlement** — prove many fills in one settlement pass, so per-intent settlement overhead stops scaling with volume.
+- **Solver-fronted actions** — let a solver front a user-defined action (a swap, a vault entry) and prove the user's signed authorisation and the resulting execution.
+- **Cross-chain governance** — let holders vote on whichever chain they hold on, and prove outcomes back to a canonical chain for aggregation.
+
+→ [How Prove API works](./how-prove-api-works.mdx) · [Prover Integration](<../get started/prove-api-V2/decodingProverReturn.mdx>)
+
+## Keep contract state in sync
+
+One deployment writes; every other deployment learns about it. Needs **Prove API**, usually with a keeper or the writing user submitting.
+
+- **Lending markets** — synchronise the yield-affecting events that determine rates, so APY stays consistent across deployments.
+- **Yield aggregation** — consolidate positions held on several chains into one reported figure, or expand a single-chain vault to more chains without duplicating the backend.
+- **Treasury and reserve status** — relay reserve, yield or attestation state for a stablecoin or structured product to every chain it trades on.
+
+→ [Simple key value app](../examples/simple-key-value-app.mdx) — the reference implementation of this pattern
+
+## Build once, serve everywhere
+
+Publish on one chain; let anyone prove it wherever they need it. Needs **Prove API**.
+
+- **Data feeds** — serve values from a single chain and let consumers prove the value they need, when they need it, instead of paying to push updates everywhere.
+- **Optimistic oracle results** — resolve once on the chain where resolution happens, then prove the outcome to every chain that cares.
+- **Stablecoin extensions** — extend to a new chain without replicating the issuance or accounting backend.
+
+The economics are the point: pushing state to *n* chains costs *n* messages, while proving costs one write and a proof per consumer who actually needs it.
+
+## Compose across chains
+
+Treat several chains as one execution environment. Needs **Prove API**, and often **Execute API** for the delivery half.
+
+- **Multi-source funding** — draw funds from balances on several chains to satisfy one user operation, and repay each source with a single proof of the outcome.
+- **Chained transactions** — run order-dependent workflows across chains (act on A, then B, fall back to A on failure) with each checkpoint proven rather than assumed.
+- **Offloaded computation** — do compute-heavy matching or auctions on whichever chain is best suited, then prove the result back to where settlement happens.
+
+→ [Chain abstraction](../examples/chain_abstraction.md) · [Choosing an API](./choosing-an-api.mdx)
+
+## Delivery without proving
+
+Sometimes the hard part is not verification — it is running submission infrastructure. Needs **Execute API** in pure execution mode.
+
+- **Relaying canonical bridge transfers** — submit the destination side of a native bridge transfer on a user's behalf, so they never operate a relayer. This is how Polymer supports the slippage-free USDC path on Circle CCTP v2.
+- **Arbitrary destination calls** — hand Polymer a contract call and have it land, with wallet, nonce, retry and gas handling included.
+
+→ [How Execute API works](./how-execute-api-works.mdx)
+
+## Flagships
+
+- **Slippage-free USDC bridge (Circle CCTP v2)** — Execute API, pure execution. A free ~20-minute path and a ~20-second fast path at 1 bps, with no relayer for the user to run.
+- **Open Intents Framework (OIF)** — Prove API. Solver fills proven on one chain and used to settle and repay on another, in production across intent protocols and their solver networks.
+
+Each has processed over **$1.5 billion** in cumulative volume.
+
+## Next
+
+- [Quickstart](<../get started/quickstart.mdx>) — build the four-step flow
+- [Trust model](./trust-model.mdx) — what you must validate before acting on a proof


### PR DESCRIPTION
Learn explained the mechanism well but never answered the two questions integrators actually block on — **which API do I need**, and **how much should I trust an attestation**. It also mixed a mechanism-first reference voice with a page of positioning copy. This reshapes the section into a path a reader can follow from "what is this" to "here is the code", and removes third-party names.

## Sidebar after this change

```
Learn
├── About Polymer            what it is, two APIs, where to go next
├── Proofs vs Messaging      the architecture comparison  (rewritten)
├── Choosing an API          Prove or Execute             (new)
├── How Prove API works      unchanged mechanism
├── How Execute API works    unchanged mechanism
├── Trust Model              what you're trusting         (new)
└── Use Cases               13 patterns, no names         (new)
```

Positioning now precedes mechanism. No filenames changed, so **no URLs move** and the four existing `/docs/learn/*` redirects still resolve.

## Third-party names

Removed: Eco, Catalyst, RiftLend, Superform, UMA, OneBalance, Biconomy, Everclear, LI.FI, and the LZ/HL fee comparison. Verified zero remaining matches under `docs/build/learn/`.

Kept, as the rails we build on rather than users of ours: Circle CCTP v2, Open Intents Framework, ERC references. Without them the flagship descriptions lose their anchors.

The 13 use cases survive as patterns — "prove that a solver's fill occurred before repaying on the origin chain" instead of "(e.g., Eco, Catalyst)". Five of the thirteen previously named someone; eight were already generic.

## New: Trust Model

The biggest content gap. Learn's entire security story was three bullets in a tip box. This page states plainly that `validateEvent` verifies **Polymer's signature** and does not re-verify the source chain's consensus on-chain — there is no light client in the destination contract — and frames that as the deliberate trade that makes verification cost a fraction of a cent on every chain. It then separates liveness failure (redundancy absorbs it) from safety failure (needs m sources wrong together), covers independent verification via `inspectPolymerState`, and tabulates the five checks that stay the application's job.

**Deliberately not asserted:** the values of m and n, who operates the source set, key management, or any economic/slashing guarantee. "m-of-n" appears throughout the docs and the numbers are published nowhere, so I wrote only what the existing pages support rather than inventing figures. See the questions below.

## New: Choosing an API

Promoted out of a two-bullet section at the bottom of `how-execute-api-works` — the weakest placement for the first real decision an integrator makes. Comparison table across proof generation, submission, gas, validation, infrastructure, and availability, plus the four-step integration common to both paths.

The through-line added in several places: Execute API changes who *delivers* the proof, never who *checks* it.

## Rewritten: Proofs vs Messaging

Now the comparison its sidebar label always promised, instead of an H1 reading "Why Devs Choose Polymer". Adds what you deploy under each model, and an honest section on the obligations proving *moves* rather than removes — anyone can submit a valid proof, which is why validation lives in your contract — plus three cases where messaging is genuinely the better fit.

## Needs your input

1. **m and n.** Publishing them would make the trust model page substantially stronger. If they are deliberately unpublished, worth saying so explicitly rather than leaving readers to wonder.
2. **The $1.5B figure.** Reworded to "cumulative volume" so it cannot become false, but it is still undated and unsourced.
3. **Two diagrams dropped.** The messaging and Polymer architecture images in `messaging-vs-proofs` were served from `github.com/user-attachments/` and are replaced by an inline ASCII diagram and a comparison table, matching the style of `how-prove-api-works`. If you want the visuals back they should be rehosted under `static/img/` — happy to restore them either way.
4. **Execute API availability** is now stated consistently as partner-only on both pages. Release Notes still calls it an open beta.

## Verification

`npm run build` passes. With `onBrokenLinks: 'throw'` set, that confirms every internal link across the three new pages resolves. Sidebar order and all seven generated routes checked in the built output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)