### PR TITLE
docs: replace the $1.5B volume figure with "billions" plus the analytics link

### DIFF
--- a/docs/build/learn/about-polymer.mdx
+++ b/docs/build/learn/about-polymer.mdx
@@ -35,7 +35,7 @@ Both APIs sit on the same proving engine: Polymer reads chain state from many in
 
 ## What Polymer powers
 
-Each of these flagships has processed over **$1.5 billion** in cumulative volume.
+Each of these flagships has processed **billions** in cumulative volume — see the [analytics dashboard](https://dashboard.polymerlabs.org/analytics) for current figures.
 
 - **Slippage-free USDC bridge (Circle CCTP v2) — the flagship Execute API use case.** Users move canonical USDC across chains with no slippage — a free ~20-minute slow path (CCTP v2 standard transfer) and a ~20-second fast path for 1 bps (CCTP v2 Fast Transfer). Polymer provides the **execution/relaying** via the Execute API so users never run their own relayer. This flow uses relaying only — no Prove API.
 - **Open Intents Framework (OIF) — the flagship Prove API use case.** The Prove API powers OIF and runs in production for intent protocols and their solver networks: a solver's fill on one chain is proven and used to settle and repay on another. It also powers synced contract state, cross-chain governance, and similar prove-and-act flows.

--- a/docs/build/learn/use-cases/index.mdx
+++ b/docs/build/learn/use-cases/index.mdx
@@ -61,7 +61,7 @@ Sometimes the hard part is not verification — it is running submission infrast
 - **Slippage-free USDC bridge (Circle CCTP v2)** — Execute API, pure execution. A free ~20-minute path and a ~20-second fast path at 1 bps, with no relayer for the user to run.
 - **Open Intents Framework (OIF)** — Prove API. Solver fills proven on one chain and used to settle and repay on another, in production across intent protocols and their solver networks.
 
-Each has processed over **$1.5 billion** in cumulative volume.
+Each has processed **billions** in cumulative volume — see the [analytics dashboard](https://dashboard.polymerlabs.org/analytics) for current figures.
 
 ## Worked examples
 


### PR DESCRIPTION
Stacked on #380 — **base is `docs/merge-examples-into-use-cases`**, so the diff here is just this change. Merge order: #379 → #380 → this. Each retargets automatically as the one below it lands.

Both occurrences of the figure now read:

> Each of these flagships has processed **billions** in cumulative volume — see the [analytics dashboard](https://dashboard.polymerlabs.org/analytics) for current figures.

| File | Before | After |
| --- | --- | --- |
| `learn/about-polymer.mdx` | over **$1.5 billion** in cumulative volume | **billions** in cumulative volume + link |
| `learn/use-cases/index.mdx` | over **$1.5 billion** in cumulative volume | **billions** in cumulative volume + link |

Zero remaining matches for `1.5 billion` or `$1.5` anywhere under `docs/`.

Dropped "over" along with the number — "over billions" doesn't parse, and "billions" is already the vague form.

## Why this is the better shape

The figure entered the docs on 2026-08-24 in `9505151`, undated and unsourced, and would have needed a manual edit every time it went stale. Pointing at the dashboard makes the claim self-maintaining and checkable.

## Note

The external link isn't covered by `onBrokenLinks`, which only validates relative internal links, and I did not fetch it — worth a click to confirm `/analytics` is the right path and is reachable without a login.

`npm run build` passes; both rendered sentences and the link target verified in the built output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)