### PR TITLE
docs: rename Examples to Explorations and drop the vendor name from it

### DIFF
--- a/docs/build/examples/_category_.json
+++ b/docs/build/examples/_category_.json
@@ -1,5 +1,5 @@
 {
-    "label": "Examples",
+    "label": "Explorations",
     "position": 3,
     "collapsed": true,
     "link": {

--- a/docs/build/examples/chain_abstraction.md
+++ b/docs/build/examples/chain_abstraction.md
@@ -10,7 +10,7 @@ Chain Abstraction protocols are redefining interoperability by combining resourc
 
 The critical element here is repayment. Solvers are only repaid if the user operation succeeds, and this is precisely where the Prove API steps in. It provides developers with execution proofs to validate user operations and facilitate repayments.
 
-**Openfort** is one of the first teams leveraging the Prove API, pushing the boundaries of chain abstraction. Openfort extends ERC4337 by incorporating an invoice manager and settlement system, enabling cross-chain functionality with Polymer. (See the [Openfort Chain Abstraction repository](https://github.com/openfort-xyz/openfort-chain-abstraction)).
+Teams building on the Prove API extend ERC4337 with an **invoice manager** and settlement system, which is what makes the cross-chain repayment leg work. The walkthrough below follows that design: an invoice is emitted where the user operation is sponsored, then proven on the chain that holds the funds.
 
 <div style={{position: 'relative', paddingBottom: '59.31830676195712%', height: 0}}><iframe src="https://github.com/user-attachments/assets/34cf828f-27e2-4f61-b86a-626f46cf0892" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style={{position: 'absolute', top: 0, left: 0, width: '100%', height: '100%'}}></iframe></div>
 
@@ -19,7 +19,7 @@ The critical element here is repayment. Solvers are only repaid if the user oper
 
 ## End-to-End Overview
 
-Applications using Openfort’s WalletSDK can abstract their application instances deployed across various chains and allow users to instantly interact with their application. 
+A wallet SDK can abstract an application's instances deployed across various chains and let users interact with any of them instantly. 
 ![image](https://github.com/user-attachments/assets/dcf2aac7-d45e-4966-84ad-5ec90cca05d7)
 
 
@@ -27,7 +27,7 @@ Applications using Openfort’s WalletSDK can abstract their application instanc
 
 1. **User Interaction**: When a user interacts with the application, a UserOp is created containing details about the tokens the user will pay with and the sponsor token chain. This data is sent to an ERC4337-compatible Paymaster as `paymasterAndData`.
 2. **Invoice Creation**: Once the user request is fronted by a solver or the application’s excess liquidity, a `createInvoice` generates and emits an `invoiceID` in the post operation. This globally unique identifier secures repayments.
-3. **Proof Request**: Openfort’s backend requests a proof for the `invoiceID` event from the Prove API.
+3. **Proof Request**: The application's backend requests a proof for the `invoiceID` event from the Prove API.
 4. **Repayment**: Using the execution proof, the backend calls the repay function to settle the `invoiceID` and repay the sponsor tokens.
 
 <br/>
@@ -136,7 +136,7 @@ The key advantage here is that Polymer validates the log with a single call and 
 - The emitting contract (in this case, the paymaster)
 - All related topics and unindexed data, including the invoiceID hash from another chain
 
-Since the context is also maintained by the Invoice Manager and the invoiceID, it ensures end-to-end mapping of the UserOp. In the future, this will enable any solver to request settlement without requiring the Openfort backend to perform transactions.
+Since the context is also maintained by the Invoice Manager and the invoiceID, it ensures end-to-end mapping of the UserOp. In the future, this will enable any solver to request settlement without requiring the application's backend to perform transactions.
 
 Additionally, the Invoice Manager maintains a record of already paid invoiceIDs, effectively preventing double-spend attacks.
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -82,6 +82,8 @@ const config = {
           { from: '/docs/build/why polymer/examples/simple-key-value-app', to: '/docs/build/examples/simple-key-value-app' },
           { from: '/docs/build/why polymer/examples/multi-rollup_apps', to: '/docs/build/examples/simple-key-value-app' },
           { from: '/docs/build/why polymer/examples/chain_abstraction', to: '/docs/build/examples/chain_abstraction' },
+          // "Examples" category renamed to "Explorations"; its generated index moved.
+          { from: '/docs/category/examples', to: '/docs/category/explorations' },
         ],
       },
     ],


### PR DESCRIPTION
Based on `main`, independent of the Learn stack — see the note at the bottom.

## Rename

The category label becomes **Explorations**:

```
Build
├── Key Network Information
├── Learn
├── Get Started
├── Explorations          ← was "Examples"
├── Release Notes
└── Contact Us
```

The directory stays `examples/`, so **every page URL is unchanged**. Only the generated category index moves, and that is redirected:

| From | To |
| --- | --- |
| `/docs/category/examples` | `/docs/category/explorations` |

I kept the directory name deliberately — renaming it to `explorations/` would move `/docs/build/examples/simple-key-value-app` and `/docs/build/examples/chain_abstraction`, which are the two URLs the older `why polymer` redirects already point at. Say the word if you want the paths to match the label and I'll do it with redirects.

## Vendor name removed

`chain_abstraction` named one team four times. Each becomes the pattern instead:

| Before | After |
| --- | --- |
| "**Openfort** is one of the first teams leveraging the Prove API … Openfort extends ERC4337 … (See the Openfort Chain Abstraction repository)" | "Teams building on the Prove API extend ERC4337 with an **invoice manager** and settlement system, which is what makes the cross-chain repayment leg work. The walkthrough below follows that design…" |
| "Applications using Openfort's WalletSDK can abstract…" | "A wallet SDK can abstract an application's instances…" |
| "Openfort's backend requests a proof…" | "The application's backend requests a proof…" |
| "without requiring the Openfort backend to perform transactions" | "without requiring the application's backend to perform transactions" |

The quoted contract code is untouched — only the prose around it. Zero remaining matches for the name anywhere under `docs/`.

## One attribution I did not touch

`simple-key-value-app` says State Sync is "**built by our community**" and links a community repo by name. That is credit for someone's work rather than a competitor or customer reference, so removing it silently felt wrong. Happy to strip or reword it if you want it gone.

## Relationship to the open Learn PRs

#380 folds this same category into Learn → Use Cases and deletes it. That is now superseded by this PR — the two conflict directly. Suggested resolution:

- Close #380.
- #381 (the "billions" wording) is stacked on #380 and touches `use-cases/index.mdx`, which only exists there. I can rebase it onto #379 so it edits `use-cases.mdx` instead — say the word.
- #379 (the Learn restructure) is unaffected either way.

## Verification

`npm run build` passes. Checked in the built output: the sidebar reads "Explorations", the category index generates at `/docs/category/explorations`, the old URL emits the redirect, and the four rewritten paragraphs render as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)