### PR TITLE
docs: nest Use Cases and Explorations under a Learn → Examples category

### DIFF
--- a/docs/build/get started/prove-api-V2/decodingProverReturn.mdx
+++ b/docs/build/get started/prove-api-V2/decodingProverReturn.mdx
@@ -12,7 +12,7 @@ import TabItem from '@theme/TabItem';
 import Admonition from '@theme/Admonition';
 
 <Admonition type="info">
-This guide explains how to interpret and decode the returns from the `CrossL2ProverV2` contract, using a practical [simple key-value app example](https://docs.polymerlabs.org/docs/build/examples/simple-key-value-app) to demonstrate the complete process.
+This guide explains how to interpret and decode the returns from the `CrossL2ProverV2` contract, using a practical [simple key-value app example](<../../learn/examples/explorations/simple-key-value-app.mdx>) to demonstrate the complete process.
 </Admonition>
 
 ## Overview

--- a/docs/build/learn/about-polymer.mdx
+++ b/docs/build/learn/about-polymer.mdx
@@ -35,12 +35,12 @@ Both APIs sit on the same proving engine: Polymer reads chain state from many in
 
 ## What Polymer powers
 
-Each of these flagships has processed over **$1.5 billion** in cumulative volume.
+Each of these flagships has processed **billions** in cumulative volume — see the [analytics dashboard](https://dashboard.polymerlabs.org/analytics) for current figures.
 
 - **Slippage-free USDC bridge (Circle CCTP v2) — the flagship Execute API use case.** Users move canonical USDC across chains with no slippage — a free ~20-minute slow path (CCTP v2 standard transfer) and a ~20-second fast path for 1 bps (CCTP v2 Fast Transfer). Polymer provides the **execution/relaying** via the Execute API so users never run their own relayer. This flow uses relaying only — no Prove API.
 - **Open Intents Framework (OIF) — the flagship Prove API use case.** The Prove API powers OIF and runs in production for intent protocols and their solver networks: a solver's fill on one chain is proven and used to settle and repay on another. It also powers synced contract state, cross-chain governance, and similar prove-and-act flows.
 
-→ [Use cases](./use-cases.mdx) for the full set of patterns Polymer supports
+→ [Use cases](./examples/use-cases.mdx) for the full set of patterns Polymer supports
 
 ## Where to go next
 

--- a/docs/build/learn/examples/_category_.json
+++ b/docs/build/learn/examples/_category_.json
@@ -1,6 +1,6 @@
 {
-    "label": "Explorations",
-    "position": 3,
+    "label": "Examples",
+    "position": 6,
     "collapsed": true,
     "link": {
       "type": "generated-index"

--- a/docs/build/learn/examples/explorations/_category_.json
+++ b/docs/build/learn/examples/explorations/_category_.json
@@ -1,0 +1,8 @@
+{
+    "label": "Explorations",
+    "position": 2,
+    "collapsed": true,
+    "link": {
+      "type": "generated-index"
+    }
+  }

--- a/docs/build/learn/examples/explorations/chain_abstraction.md
+++ b/docs/build/learn/examples/explorations/chain_abstraction.md
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 1
-sidebar_label: 'For Chain Abstraction'
+sidebar_position: 2
+sidebar_label: 'Chain Abstraction'
 ---
 
 

--- a/docs/build/learn/examples/explorations/simple-key-value-app.mdx
+++ b/docs/build/learn/examples/explorations/simple-key-value-app.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 0
+sidebar_position: 1
 sidebar_label: 'Simple Key Value App'
 ---
 

--- a/docs/build/learn/examples/use-cases.mdx
+++ b/docs/build/learn/examples/use-cases.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 1
 sidebar_label: 'Use Cases'
 ---
 
@@ -16,7 +16,7 @@ Prove that something *happened* on one chain, then act on it somewhere else. Nee
 - **Solver-fronted actions** — let a solver front a user-defined action (a swap, a vault entry) and prove the user's signed authorisation and the resulting execution.
 - **Cross-chain governance** — let holders vote on whichever chain they hold on, and prove outcomes back to a canonical chain for aggregation.
 
-→ [How Prove API works](./how-prove-api-works.mdx) · [Prover Integration](<../get started/prove-api-V2/decodingProverReturn.mdx>)
+→ [How Prove API works](../how-prove-api-works.mdx) · [Prover Integration](<../../get started/prove-api-V2/decodingProverReturn.mdx>)
 
 ## Keep contract state in sync
 
@@ -26,7 +26,7 @@ One deployment writes; every other deployment learns about it. Needs **Prove API
 - **Yield aggregation** — consolidate positions held on several chains into one reported figure, or expand a single-chain vault to more chains without duplicating the backend.
 - **Treasury and reserve status** — relay reserve, yield or attestation state for a stablecoin or structured product to every chain it trades on.
 
-→ [Simple key value app](../examples/simple-key-value-app.mdx) — the reference implementation of this pattern
+→ [Simple key value app](./explorations/simple-key-value-app.mdx) — the reference implementation of this pattern
 
 ## Build once, serve everywhere
 
@@ -46,7 +46,7 @@ Treat several chains as one execution environment. Needs **Prove API**, and ofte
 - **Chained transactions** — run order-dependent workflows across chains (act on A, then B, fall back to A on failure) with each checkpoint proven rather than assumed.
 - **Offloaded computation** — do compute-heavy matching or auctions on whichever chain is best suited, then prove the result back to where settlement happens.
 
-→ [Chain abstraction](../examples/chain_abstraction.md) · [Choosing an API](./choosing-an-api.mdx)
+→ [Chain abstraction](./explorations/chain_abstraction.md) · [Choosing an API](../choosing-an-api.mdx)
 
 ## Delivery without proving
 
@@ -55,16 +55,23 @@ Sometimes the hard part is not verification — it is running submission infrast
 - **Relaying canonical bridge transfers** — submit the destination side of a native bridge transfer on a user's behalf, so they never operate a relayer. This is how Polymer supports the slippage-free USDC path on Circle CCTP v2.
 - **Arbitrary destination calls** — hand Polymer a contract call and have it land, with wallet, nonce, retry and gas handling included.
 
-→ [How Execute API works](./how-execute-api-works.mdx)
+→ [How Execute API works](../how-execute-api-works.mdx)
 
 ## Flagships
 
 - **Slippage-free USDC bridge (Circle CCTP v2)** — Execute API, pure execution. A free ~20-minute path and a ~20-second fast path at 1 bps, with no relayer for the user to run.
 - **Open Intents Framework (OIF)** — Prove API. Solver fills proven on one chain and used to settle and repay on another, in production across intent protocols and their solver networks.
 
-Each has processed over **$1.5 billion** in cumulative volume.
+Each has processed **billions** in cumulative volume — see the [analytics dashboard](https://dashboard.polymerlabs.org/analytics) for current figures.
+
+## Explorations
+
+Two of these patterns are worked through end to end — contract code, proof request, and destination validation.
+
+- **[Simple key value app](./explorations/simple-key-value-app.mdx)** — the synced-state pattern. Writes on one chain propagate to every other deployment, with the full `setValue` / `setValueFromSource` pair and each security check in place.
+- **[Chain abstraction](./explorations/chain_abstraction.md)** — the prove-an-action pattern. An invoice is emitted when a solver fronts a user operation, then proven on the chain holding the funds to release repayment.
 
 ## Next
 
-- [Quickstart](<../get started/quickstart.mdx>) — build the four-step flow
-- [Trust model](./trust-model.mdx) — what you must validate before acting on a proof
+- [Quickstart](<../../get started/quickstart.mdx>) — build the four-step flow
+- [Trust model](../trust-model.mdx) — what you must validate before acting on a proof

--- a/docs/build/learn/how-execute-api-works.mdx
+++ b/docs/build/learn/how-execute-api-works.mdx
@@ -46,4 +46,4 @@ Execute API changes who submits the destination transaction. It does not change 
 
 - [Choosing an API](./choosing-an-api.mdx) — Prove or Execute, side by side
 - [Execute API reference](<../get started/execute-api.mdx>) — methods, parameters and responses
-- [Use cases](./use-cases.mdx) — what people build with pure execution
+- [Use cases](./examples/use-cases.mdx) — what people build with pure execution

--- a/docs/build/learn/messaging-vs-proofs.mdx
+++ b/docs/build/learn/messaging-vs-proofs.mdx
@@ -72,5 +72,5 @@ These checks are not optional. [Prover Integration](<../get started/prove-api-V2
 ## Next
 
 - [Choosing an API](./choosing-an-api.mdx) — Prove or Execute
-- [Use cases](./use-cases.mdx) — the patterns this shape unlocks
+- [Use cases](./examples/use-cases.mdx) — the patterns this shape unlocks
 - [Quickstart](<../get started/quickstart.mdx>) — the four-step integration

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -79,11 +79,12 @@ const config = {
           { from: '/docs/learn/how-prove-api-works', to: '/docs/build/learn/how-prove-api-works' },
           { from: '/docs/learn/how-execute-api-works', to: '/docs/build/learn/how-execute-api-works' },
           { from: '/docs/learn/messaging-vs-proofs', to: '/docs/build/learn/messaging-vs-proofs' },
-          { from: '/docs/build/why polymer/examples/simple-key-value-app', to: '/docs/build/examples/simple-key-value-app' },
-          { from: '/docs/build/why polymer/examples/multi-rollup_apps', to: '/docs/build/examples/simple-key-value-app' },
-          { from: '/docs/build/why polymer/examples/chain_abstraction', to: '/docs/build/examples/chain_abstraction' },
-          // "Examples" category renamed to "Explorations"; its generated index moved.
-          { from: '/docs/category/examples', to: '/docs/category/explorations' },
+          { from: '/docs/build/why polymer/examples/simple-key-value-app', to: '/docs/build/learn/examples/explorations/simple-key-value-app' },
+          { from: '/docs/build/why polymer/examples/multi-rollup_apps', to: '/docs/build/learn/examples/explorations/simple-key-value-app' },
+          { from: '/docs/build/why polymer/examples/chain_abstraction', to: '/docs/build/learn/examples/explorations/chain_abstraction' },
+          // Examples moved under Learn -> Examples -> Explorations.
+          { from: '/docs/build/examples/simple-key-value-app', to: '/docs/build/learn/examples/explorations/simple-key-value-app' },
+          { from: '/docs/build/examples/chain_abstraction', to: '/docs/build/learn/examples/explorations/chain_abstraction' },
         ],
       },
     ],


### PR DESCRIPTION
Rebuilt on current `main` (`5a3606c`) — one commit, conflicts gone.

## Structure

```
Learn
├── About Polymer
├── Proofs vs Messaging
├── Choosing an API
├── How Prove API works
├── How Execute API works
├── Trust Model
└── Examples              ← new category, at the bottom of Learn
    ├── Use Cases
    └── Explorations
        ├── Simple Key Value App
        └── Chain Abstraction
```

The patterns page and the worked walkthroughs now sit together at the end of the learning path. The top-level Explorations tab is removed.

## Also carried here: the "billions" wording

#381 was merged into the `docs/learn-restructure` branch rather than into `main`, so it never landed — `main` still reads "over **$1.5 billion** in cumulative volume" in both places. Fixed here; both now point at the [analytics dashboard](https://dashboard.polymerlabs.org/analytics) instead of hardcoding a figure.

## Why this branch was force-pushed

The first version of this PR was based on `4d173bb` and re-applied changes that had since reached `main` via #379 and #382, which is what produced the conflicts on `_category_.json`, `chain_abstraction.md` and `docusaurus.config.js`. Rebuilding on current `main` rather than merging also preserves your `f6c66ef` edit — the "When messaging is the better fit" section you removed stays removed.

## URLs

| From | To |
| --- | --- |
| `/docs/build/examples/simple-key-value-app` | `/docs/build/learn/examples/explorations/simple-key-value-app` |
| `/docs/build/examples/chain_abstraction` | `/docs/build/learn/examples/explorations/chain_abstraction` |

The three older `why polymer` redirects are retargeted to the same destinations. `/docs/category/examples` resolves again, now as the Learn → Examples index, so the redirect #382 added for it is dropped as unnecessary.

## Two cosmetic notes

**Depth.** The walkthroughs sit five levels down (Build → Learn → Examples → Explorations → page). That is what "Use Cases as one and Explorations as the second" implies and it is built as asked — but flattening Explorations into two pages directly under Examples would lose a level and read much the same.

**Name overlap.** The category is `Examples` with directory `examples/`, and the walkthroughs live under `explorations/`, so URLs read `/learn/examples/explorations/…`. Slightly redundant, no URLs would break to change it.

## Verification

`npm run build` passes, so every internal link resolves under `onBrokenLinks: 'throw'`. Verified in the built output: the sidebar nests exactly as above, both old example URLs emit the right redirect, both category index pages generate, and no `$1.5 billion` string remains anywhere under `docs/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)